### PR TITLE
Use TLS consul client if consul cluster specifies https

### DIFF
--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -91,6 +91,9 @@ type RepConfig struct {
 	CellID                    string   `json:"cell_id"`
 	CommunicationTimeout      Duration `json:"communication_timeout,omitempty"`
 	ConsulCluster             string   `json:"consul_cluster"`
+	ConsulCACert              string   `json:"consul_ca_cert"`
+	ConsulClientCert          string   `json:"consul_client_cert"`
+	ConsulClientKey           string   `json:"consul_client_key"`
 	DropsondePort             int      `json:"dropsonde_port,omitempty"`
 	EnableLegacyAPIServer     bool     `json:"enable_legacy_api_endpoints"`
 	EvacuationPollingInterval Duration `json:"evacuation_polling_interval,omitempty"`

--- a/cmd/rep/config/config_test.go
+++ b/cmd/rep/config/config_test.go
@@ -62,9 +62,12 @@ var _ = Describe("RepConfig", func() {
 			"container_metrics_report_interval": "16s",
 			"session_name": "test",
 			"consul_cluster": "test cluster",
+			"consul_ca_cert": "/tmp/consul_ca_cert",
+			"consul_client_cert": "/tmp/consul_client_cert",
+			"consul_client_key": "/tmp/consul_client_key",
 			"lock_ttl": "5s",
 			"lock_retry_interval": "5s",
-      "listen_addr": "0.0.0.0:8080",
+			"listen_addr": "0.0.0.0:8080",
 			"listen_addr_securable": "0.0.0.0:8081",
 			"listen_addr_admin": "0.0.0.1:8081",
 			"require_tls": true,
@@ -86,12 +89,12 @@ var _ = Describe("RepConfig", func() {
 			"bbs_client_key_file": "/tmp/bbs_client_key",
 			"bbs_client_session_cache_size": 100,
 			"bbs_max_idle_conns_per_host": 10,
-      "preloaded_root_fs": ["test:value", "test2:value2"],
-      "supported_providers": ["provider1", "provider2"],
-      "garden_healthcheck_process_env": ["env1", "env2"],
-      "garden_healthcheck_process_args": ["arg1", "arg2"],
-      "placement_tags": ["tag1", "tag2"],
-      "optional_placement_tags": ["otag1", "otag2"]
+			"preloaded_root_fs": ["test:value", "test2:value2"],
+			"supported_providers": ["provider1", "provider2"],
+			"garden_healthcheck_process_env": ["env1", "env2"],
+			"garden_healthcheck_process_args": ["arg1", "arg2"],
+			"placement_tags": ["tag1", "tag2"],
+			"optional_placement_tags": ["otag1", "otag2"]
 		}`
 	})
 
@@ -164,6 +167,9 @@ var _ = Describe("RepConfig", func() {
 			},
 			SessionName:               "test",
 			ConsulCluster:             "test cluster",
+			ConsulCACert:              "/tmp/consul_ca_cert",
+			ConsulClientCert:          "/tmp/consul_client_cert",
+			ConsulClientKey:           "/tmp/consul_client_key",
 			LockTTL:                   config.Duration(5 * time.Second),
 			LockRetryInterval:         config.Duration(5 * time.Second),
 			ListenAddr:                "0.0.0.0:8080",

--- a/cmd/rep/main_suite_test.go
+++ b/cmd/rep/main_suite_test.go
@@ -79,9 +79,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	sqlProcess = ginkgomon.Invoke(sqlRunner)
 
 	consulRunner = consulrunner.NewClusterRunner(
-		9001+config.GinkgoConfig.ParallelNode*consulrunner.PortOffsetLength,
-		1,
-		"http",
+		consulrunner.ClusterRunnerConfig{
+			StartingPort: 9001 + config.GinkgoConfig.ParallelNode*consulrunner.PortOffsetLength,
+			NumNodes:     1,
+			Scheme:       "http",
+		},
 	)
 
 	consulRunner.Start()

--- a/generator/internal/internal_suite_test.go
+++ b/generator/internal/internal_suite_test.go
@@ -47,9 +47,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	sqlProcess = ginkgomon.Invoke(sqlRunner)
 
 	consulRunner = consulrunner.NewClusterRunner(
-		9001+config.GinkgoConfig.ParallelNode*consulrunner.PortOffsetLength,
-		1,
-		"http",
+		consulrunner.ClusterRunnerConfig{
+			StartingPort: 9001 + config.GinkgoConfig.ParallelNode*consulrunner.PortOffsetLength,
+			NumNodes:     1,
+			Scheme:       "http",
+		},
 	)
 
 	bbsPort := 13000 + GinkgoParallelNode()*2


### PR DESCRIPTION
This PR goes along with [this one](https://github.com/cloudfoundry/consuladapter/pull/7) that adds support for a TLS consul client. This is in support of the work to make consul<->rep communication more secure on Windows.

Let me know if there is anything that I should add!