### PR TITLE
Add TaskStarted, TasksSucceeded, and TasksFailed metrics

### DIFF
--- a/generator/internal/task_processor.go
+++ b/generator/internal/task_processor.go
@@ -4,6 +4,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/rep"
+	"code.cloudfoundry.org/runtimeschema/metric"
 
 	"code.cloudfoundry.org/bbs"
 	"code.cloudfoundry.org/lager"
@@ -13,6 +14,10 @@ const TaskCompletionReasonMissingContainer = "task container does not exist"
 const TaskCompletionReasonFailedToRunContainer = "failed to run container"
 const TaskCompletionReasonInvalidTransition = "invalid state transition"
 const TaskCompletionReasonFailedToFetchResult = "failed to fetch result"
+
+var TasksStarted = metric.Counter("CellTasksStarted")
+var TasksFailed = metric.Counter("CellTasksFailed")
+var TasksSucceeded = metric.Counter("CellTasksSucceeded")
 
 //go:generate counterfeiter -o fake_internal/fake_task_processor.go task_processor.go TaskProcessor
 
@@ -84,6 +89,7 @@ func (p *taskProcessor) processActiveContainer(logger lager.Logger, container ex
 	if !ok {
 		p.failTask(logger, container.Guid, TaskCompletionReasonFailedToRunContainer)
 	}
+	TasksStarted.Increment()
 }
 
 func (p *taskProcessor) processCompletedContainer(logger lager.Logger, container executor.Container) {
@@ -126,6 +132,7 @@ func (p *taskProcessor) completeTask(logger lager.Logger, container executor.Con
 			p.failTask(logger, container.Guid, TaskCompletionReasonFailedToFetchResult)
 			return
 		}
+		TasksSucceeded.Increment()
 	}
 
 	logger.Info("completing-task")
@@ -140,16 +147,23 @@ func (p *taskProcessor) completeTask(logger lager.Logger, container executor.Con
 		return
 	}
 
+	if container.RunResult.Failed {
+		// Need to increment the FailedTask Counter since if we got to this point we have not called p.failTask()
+		TasksFailed.Increment()
+	}
+
 	logger.Info("succeeded-completing-task")
 }
 
 func (p *taskProcessor) failTask(logger lager.Logger, guid string, reason string) {
 	logger.Info("failing-task")
+	// Increment the failed task counter
+	TasksFailed.Increment()
+
 	err := p.bbsClient.FailTask(logger, guid, reason)
 	if err != nil {
 		logger.Error("failed-failing-task", err)
 		return
 	}
-
 	logger.Info("succeeded-failing-task")
 }


### PR DESCRIPTION
I investigated putting these metrics into BBS but there was several issues.

1) We do not have all the information in the handlers (cell_id) on all the calls.  We would have had to done another DB lookup in the handler to get this or change the interface to add passing the cell_id in all those calls.

2) There is no API that is useable to Add a TAG to a counter Metric.  If this is added we can investigate this further.

These metrics are vital to our monitoring of the Diego Environment as they can indicate issues with particular cells with staging requests failing.

Can you please look at this again and reevaluate it as we need to have this capability in the Diego release.

Thanks,

Andrew Edgar
