### PR TITLE
Support preloaded+droplet scheme in rootFS URIs

### DIFF
--- a/auctioncellrep/auction_cell_rep.go
+++ b/auctioncellrep/auction_cell_rep.go
@@ -2,6 +2,7 @@ package auctioncellrep
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -70,7 +71,8 @@ func rootFSProviders(preloaded rep.StackPathMap, arbitrary []string) rep.RootFSP
 	for stack, _ := range preloaded {
 		stacks = append(stacks, stack)
 	}
-	rootFSProviders["preloaded"] = rep.NewFixedSetRootFSProvider(stacks...)
+	rootFSProviders[models.PreloadedRootFSScheme] = rep.NewFixedSetRootFSProvider(stacks...)
+	rootFSProviders[models.PreloadedOCIRootFSScheme] = rep.NewFixedSetRootFSProvider(stacks...)
 
 	return rootFSProviders
 }
@@ -91,6 +93,13 @@ func PathForRootFS(rootFS string, stackPathMap rep.StackPathMap) (string, error)
 			return "", ErrPreloadedRootFSNotFound
 		}
 		return path, nil
+	} else if url.Scheme == models.PreloadedOCIRootFSScheme {
+		path, ok := stackPathMap[url.Opaque]
+		if !ok {
+			return "", ErrPreloadedRootFSNotFound
+		}
+
+		return fmt.Sprintf("%s:%s?%s", url.Scheme, path, url.RawQuery), nil
 	}
 
 	return rootFS, nil

--- a/rootfs_providers.go
+++ b/rootfs_providers.go
@@ -141,7 +141,6 @@ func (provider *FixedSetRootFSProvider) UnmarshalJSON(payload []byte) error {
 	provider.FixedSet = f.Set
 
 	return nil
-
 }
 
 type StringSet map[string]struct{}


### PR DESCRIPTION
The Garden team are working on cross-stack performance improvements for Cloud Foundry. [A related PR in Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/pull/854) adds a feature flag, that when enabled causes buildpack apps to use a new URI scheme when posting LRPs to the Diego BBS.

The new scheme is of the form `preloaded+droplet:<stack-name>?droplet=<droplet-uri>`. In this PR the rep translates the stack name to an absolute path, similarly to the "preloaded" rootFS provider. Garden/GrootFS will handle the downloading of the droplet and layer creation.

The LRP request from Cloud Controller will contain no `DownloadAction` for the droplet in its setup. The long-term intention is to eliminate streaming out/in from the buildpack app lifecycle completely, as it is the least performant part of that lifecycle.

[Relevant tracker story](https://www.pivotaltracker.com/story/show/147910855).

There is a [related PR in BBS](https://github.com/cloudfoundry/bbs/pull/21).