### PR TITLE
make cell_index config item part of CellState object

### DIFF
--- a/auctioncellrep/auction_cell_rep.go
+++ b/auctioncellrep/auction_cell_rep.go
@@ -28,6 +28,7 @@ var ErrNotEnoughMemory = errors.New("not enough memory for container and additio
 
 type AuctionCellRep struct {
 	cellID                   string
+	cellIndex                int
 	repURL                   string
 	stackPathMap             rep.StackPathMap
 	rootFSProviders          rep.RootFSProviders
@@ -44,6 +45,7 @@ type AuctionCellRep struct {
 
 func New(
 	cellID string,
+	cellIndex int,
 	repURL string,
 	preloadedStackPathMap rep.StackPathMap,
 	containerMetricsProvider rep.ContainerMetricsProvider,
@@ -59,6 +61,7 @@ func New(
 ) *AuctionCellRep {
 	return &AuctionCellRep{
 		cellID:                   cellID,
+		cellIndex:                cellIndex,
 		repURL:                   repURL,
 		stackPathMap:             preloadedStackPathMap,
 		rootFSProviders:          rootFSProviders(preloadedStackPathMap, arbitraryRootFSes),
@@ -218,6 +221,7 @@ func (a *AuctionCellRep) State(logger lager.Logger) (rep.CellState, bool, error)
 
 	state := rep.NewCellState(
 		a.cellID,
+		a.cellIndex,
 		a.repURL,
 		a.rootFSProviders,
 		a.convertResources(availableResources),

--- a/auctioncellrep/auction_cell_rep_test.go
+++ b/auctioncellrep/auction_cell_rep_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	repURL     = "https://foo.cell.service.cf.internal:8888"
 	cellID     = "some-cell-id"
+	cellIndex  = 0
 	linuxStack = "linux"
 	linuxPath  = "/data/rootfs/linux"
 )
@@ -59,6 +60,7 @@ var _ = Describe("AuctionCellRep", func() {
 	JustBeforeEach(func() {
 		cellRep = auctioncellrep.New(
 			cellID,
+			cellIndex,
 			repURL,
 			rep.StackPathMap{linuxStack: linuxPath},
 			fakeContainerMetricsProvider,
@@ -424,6 +426,7 @@ var _ = Describe("AuctionCellRep", func() {
 			Expect(healthy).To(BeTrue())
 
 			Expect(state.CellID).To(Equal(cellID))
+			Expect(state.CellIndex).To(Equal(cellIndex))
 			Expect(state.RepURL).To(Equal(repURL))
 
 			Expect(state.Evacuating).To(BeTrue())

--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -84,6 +84,7 @@ type RepConfig struct {
 	BBSClientKeyFile                string                `json:"bbs_client_key_file"`  // DEPRECATED. Kept around for dusts compatability
 	CaCertFile                      string                `json:"ca_cert_file"`
 	CellID                          string                `json:"cell_id"`
+	CellIndex                       int                   `json:"cell_index"`
 	CommunicationTimeout            durationjson.Duration `json:"communication_timeout,omitempty"`
 	ConsulCACert                    string                `json:"consul_ca_cert"`
 	ConsulClientCert                string                `json:"consul_client_cert"`

--- a/cmd/rep/config/config_test.go
+++ b/cmd/rep/config/config_test.go
@@ -30,6 +30,7 @@ var _ = Describe("RepConfig", func() {
 			"ca_cert_file": "/tmp/ca_cert",
 			"cache_path": "/tmp/cache",
 			"cell_id" : "cell_z1/10",
+			"cell_index": 10,
 			"communication_timeout": "11s",
 			"consul_ca_cert": "/tmp/consul_ca_cert",
 			"consul_client_cert": "/tmp/consul_client_cert",
@@ -155,6 +156,7 @@ var _ = Describe("RepConfig", func() {
 			BBSMaxIdleConnsPerHost:         10,
 			CaCertFile:                     "/tmp/ca_cert",
 			CellID:                         "cell_z1/10",
+			CellIndex:                      10,
 			CellRegistrationsLocketEnabled: true,
 			ClientLocketConfig: locket.ClientLocketConfig{
 				LocketAddress:        "0.0.0.0:909090909",

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -131,6 +131,7 @@ func main() {
 	batchContainerAllocator := auctioncellrep.NewContainerAllocator(auctioncellrep.GenerateGuid, rootFSMap, executorClient)
 	auctionCellRep := auctioncellrep.New(
 		repConfig.CellID,
+		repConfig.CellIndex,
 		url,
 		rootFSMap,
 		containerMetricsProvider,

--- a/resources.go
+++ b/resources.go
@@ -16,6 +16,7 @@ var ErrorIncompatibleRootfs = errors.New("rootfs not found")
 type CellState struct {
 	RepURL                  string `json:"rep_url"`
 	CellID                  string `json:"cell_id"`
+	CellIndex               int    `json:"cell_index"`
 	RootFSProviders         RootFSProviders
 	AvailableResources      Resources
 	TotalResources          Resources
@@ -32,6 +33,7 @@ type CellState struct {
 
 func NewCellState(
 	cellID string,
+	cellIndex int,
 	repURL string,
 	root RootFSProviders,
 	avail Resources,
@@ -48,6 +50,7 @@ func NewCellState(
 ) CellState {
 	return CellState{
 		CellID:                  cellID,
+		CellIndex:               cellIndex,
 		RepURL:                  repURL,
 		RootFSProviders:         root,
 		AvailableResources:      avail,

--- a/resources_test.go
+++ b/resources_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Resources", func() {
 
 		cellState = rep.NewCellState(
 			"cell-id",
+			0,
 			"https://foo.cell.service.cf.internal",
 			linuxOnlyRootFSProviders,
 			avail,


### PR DESCRIPTION
This PR is part of multiple PRs across [rep](https://github.com/cloudfoundry/rep), [auctioneer](https://github.com/cloudfoundry/auctioneer) and [auction](https://github.com/cloudfoundry/auction) to add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs.

PRs/issues involved:
* [rep#30](https://github.com/cloudfoundry/rep/pull/30)
* [auctioneer#8](https://github.com/cloudfoundry/auctioneer/pull/8)
* [auction#8](https://github.com/cloudfoundry/auction/pull/8)
* [diego-release#448](https://github.com/cloudfoundry/diego-release/pull/448)

### What is this change about?

These PRs combined introduce a new setting for auctioneer:
```
diego.auctioneer.bin_pack_first_fit_weight
  description: "Factor to bias against BOSH instance index number of a cell. Instead of spreading containers equally across all cell
s, cells with a lower index number will be deployed to first when this setting is > 0. (0.0 - 1.0)"
  default: 0.0
```

When `bin_pack_first_fit_weight` is set to a value > 0, it will make diego-cells with a lower BOSH instance index number more attractive to deploy LRPs to by adding "weight x diego-cell index" to the score of a diego-cell. Diego-cells will be filled up more instead spreading the LRPs across all diego-cells equally.

Setting `bin_pack_first_fit_weight` to 0.0 (the default) will effectively disable the optional weighted bin pack first fit component. Everything still keeps working as it was previously.

### What problem it is trying to solve?

With the current deployment algorithm in diego it spreads the LRPs across all diego-cell instances equally. At Mendix we have 64GB memory diego-cells. We need to have the possibility for our customers to deploy 16G containers at all times. This means that we need to have at least 1 diego-cell with 16G memory available at all times. When the LRPs are spread equally you end up with a situation where on average 25% (16/64) of the memory on all our diego-cells is not used.

### What is the impact if the change is not made?

In our case 25% of our diego-cell resources are wasted. We have been running a diego-release with these changes on top for the past months in our production Cloud Foundry foundations. We are saving ten-thousands of $$ monthly on AWS EC2 costs.

### How should this change be described in diego-release release notes?

auctioneer
* Add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs

### Please provide any contextual information.

Blog post with more information: https://cloud-infra.engineer/saving-costs-with-a-new-scheduler-in-cloud-foundry-diego/

### Tag your pair, your PM, and/or team!

I'm not sure who to tag.