### PR TITLE
Add internal routes to executor RunInfo

### DIFF
--- a/conversion_helpers.go
+++ b/conversion_helpers.go
@@ -12,6 +12,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/ecrhelper"
 	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/routing-info/internalroutes"
 )
 
 const (
@@ -197,10 +198,16 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromDesiredLRP(
 		return executor.RunRequest{}, err
 	}
 
+	internalRoutes, err := internalroutes.InternalRoutesFromRoutingInfo(*desiredLRP.Routes)
+	if err != nil {
+		return executor.RunRequest{}, err
+	}
+
 	runInfo := executor.RunInfo{
-		RootFSPath: rootFSPath,
-		CPUWeight:  uint(desiredLRP.CpuWeight),
-		Ports:      ConvertPortMappings(desiredLRP.Ports),
+		RootFSPath:     rootFSPath,
+		CPUWeight:      uint(desiredLRP.CpuWeight),
+		Ports:          ConvertPortMappings(desiredLRP.Ports),
+		InternalRoutes: internalRoutes,
 		LogConfig: executor.LogConfig{
 			Guid:       desiredLRP.LogGuid,
 			Index:      int(lrpKey.Index),


### PR DESCRIPTION
Internal routes will be used in SAN of C2C TLS certificate. We need to
pass them from desired LRP to the executor.

[#180173340](https://www.pivotaltracker.com/story/show/180173340)
