### PR TITLE
Converge metric tags

### DIFF
--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -864,6 +864,7 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 						Path: "the-path",
 						Args: []string{},
 					}),
+					MetricTags: map[string]*models.MetricTagValue{"some-tag": {Static: "some-value"}},
 				}
 				actualLRPKey := models.ActualLRPKey{
 					ProcessGuid: desiredLRP.ProcessGuid,

--- a/generator/internal/evacuation_lrp_processor.go
+++ b/generator/internal/evacuation_lrp_processor.go
@@ -102,7 +102,7 @@ func (p *evacuationLRPProcessor) processRunningContainer(logger lager.Logger, lr
 	for _, internalRoute := range lrpContainer.InternalRoutes {
 		internalRoutes = append(internalRoutes, &models.ActualLRPInternalRoute{Hostname: internalRoute.Hostname})
 	}
-	keepContainer, err := p.bbsClient.EvacuateRunningActualLRP(logger, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes)
+	keepContainer, err := p.bbsClient.EvacuateRunningActualLRP(logger, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes, lrpContainer.MetricsConfig.Tags)
 	if keepContainer == false {
 		p.containerDelegate.DeleteContainer(logger, lrpContainer.Container.Guid)
 	} else if err != nil {

--- a/generator/internal/evacuation_lrp_processor_test.go
+++ b/generator/internal/evacuation_lrp_processor_test.go
@@ -255,15 +255,17 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 				container.Ports = []executor.PortMapping{{ContainerPort: 1357, HostPort: 8642}}
 				container.InternalRoutes = internalroutes.InternalRoutes{{Hostname: "some-internal-route.apps.internal"}, {Hostname: "some-other-internal-route"}}
 				lrpNetInfo = models.NewActualLRPNetInfo(externalIP, internalIP, models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(8642, 1357))
+				container.MetricsConfig.Tags = map[string]string{"app_name": "some-application"}
 			})
 
 			It("evacuates the lrp", func() {
 				Expect(fakeBBS.EvacuateRunningActualLRPCallCount()).To(Equal(1))
-				_, actualLRPKey, actualLRPContainerKey, actualLRPNetInfo, internalRoutes := fakeBBS.EvacuateRunningActualLRPArgsForCall(0)
+				_, actualLRPKey, actualLRPContainerKey, actualLRPNetInfo, internalRoutes, metricTags := fakeBBS.EvacuateRunningActualLRPArgsForCall(0)
 				Expect(*actualLRPKey).To(Equal(lrpKey))
 				Expect(*actualLRPContainerKey).To(Equal(lrpInstanceKey))
 				Expect(*actualLRPNetInfo).To(Equal(lrpNetInfo))
 				Expect(internalRoutes).To(Equal([]*models.ActualLRPInternalRoute{{Hostname: "some-internal-route.apps.internal"}, {Hostname: "some-other-internal-route"}}))
+				Expect(metricTags).To(Equal(map[string]string{"app_name": "some-application"}))
 
 				Eventually(logger).Should(Say(
 					fmt.Sprintf(

--- a/generator/internal/ordinary_lrp_processor.go
+++ b/generator/internal/ordinary_lrp_processor.go
@@ -127,7 +127,7 @@ func (p *ordinaryLRPProcessor) processRunningContainer(logger lager.Logger, lrpC
 	for _, internalRoute := range lrpContainer.InternalRoutes {
 		internalRoutes = append(internalRoutes, &models.ActualLRPInternalRoute{Hostname: internalRoute.Hostname})
 	}
-	err = p.bbsClient.StartActualLRP(logger, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes)
+	err = p.bbsClient.StartActualLRP(logger, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes, lrpContainer.MetricsConfig.Tags)
 	bbsErr := models.ConvertError(err)
 	if bbsErr != nil && bbsErr.Type == models.Error_ActualLRPCannotBeStarted {
 		p.containerDelegate.StopContainer(logger, lrpContainer.Guid)

--- a/generator/internal/ordinary_lrp_processor_test.go
+++ b/generator/internal/ordinary_lrp_processor_test.go
@@ -217,15 +217,17 @@ var _ = Describe("OrdinaryLRPProcessor", func() {
 						container.InternalIP = "2.2.2.2"
 						container.Ports = []executor.PortMapping{{ContainerPort: 8080, HostPort: 61999}}
 						container.InternalRoutes = internalroutes.InternalRoutes{{Hostname: "some-internal-route.apps.internal"}, {Hostname: "some-other-internal-route"}}
+						container.MetricsConfig.Tags = map[string]string{"app_name": "some-application"}
 					})
 
 					It("starts the lrp", func() {
 						Expect(bbsClient.StartActualLRPCallCount()).To(Equal(1))
-						_, lrpKey, instanceKey, netInfo, internalRoutes := bbsClient.StartActualLRPArgsForCall(0)
+						_, lrpKey, instanceKey, netInfo, internalRoutes, metricTags := bbsClient.StartActualLRPArgsForCall(0)
 						Expect(*lrpKey).To(Equal(expectedLrpKey))
 						Expect(*instanceKey).To(Equal(expectedInstanceKey))
 						Expect(*netInfo).To(Equal(expectedNetInfo))
 						Expect(internalRoutes).To(Equal([]*models.ActualLRPInternalRoute{{Hostname: "some-internal-route.apps.internal"}, {Hostname: "some-other-internal-route"}}))
+						Expect(metricTags).To(Equal(map[string]string{"app_name": "some-application"}))
 
 						Eventually(logger).Should(Say(
 							fmt.Sprintf(

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -39,6 +39,7 @@ func New(
 
 		handlers[rep.StopLRPInstanceRoute] = logWrap(stopLrpHandler.ServeHTTP, logger)
 		handlers[rep.UpdateLRPInstanceRoute] = logWrap(updateLrpHandler.ServeHTTP, logger)
+		handlers[rep.UpdateLRPInstanceRoute_r0] = logWrap(updateLrpHandler.ServeHTTP, logger)
 		handlers[rep.CancelTaskRoute] = logWrap(cancelTaskHandler.ServeHTTP, logger)
 	} else {
 		pingHandler := newPingHandler(requestMetrics)

--- a/routes.go
+++ b/routes.go
@@ -7,9 +7,10 @@ const (
 	ContainerMetricsRoute = "ContainerMetrics"
 	PerformRoute          = "PERFORM"
 
-	UpdateLRPInstanceRoute = "UpdateLRPInstance"
-	StopLRPInstanceRoute   = "StopLRPInstance"
-	CancelTaskRoute        = "CancelTask"
+	UpdateLRPInstanceRoute    = "UpdateLRPInstance"
+	UpdateLRPInstanceRoute_r0 = "UpdateLRPInstance_r0"
+	StopLRPInstanceRoute      = "StopLRPInstance"
+	CancelTaskRoute           = "CancelTask"
 
 	SimResetRoute = "RESET"
 
@@ -26,7 +27,8 @@ func NewRoutes(networkAccessible bool) rata.Routes {
 			rata.Route{Path: "/container_metrics", Method: "GET", Name: ContainerMetricsRoute},
 			rata.Route{Path: "/work", Method: "POST", Name: PerformRoute},
 
-			rata.Route{Path: "/v1/lrps/:process_guid/instances/:instance_guid", Method: "PUT", Name: UpdateLRPInstanceRoute},
+			rata.Route{Path: "/v2/lrps/:process_guid/instances/:instance_guid", Method: "PUT", Name: UpdateLRPInstanceRoute},
+			rata.Route{Path: "/v1/lrps/:process_guid/instances/:instance_guid", Method: "PUT", Name: UpdateLRPInstanceRoute_r0},
 			rata.Route{Path: "/v1/lrps/:process_guid/instances/:instance_guid/stop", Method: "POST", Name: StopLRPInstanceRoute},
 			rata.Route{Path: "/v1/tasks/:task_guid/cancel", Method: "POST", Name: CancelTaskRoute},
 


### PR DESCRIPTION
Thank you for submitting a pull request to the rep repository!

We appreciate the contribution. To help us understand the context for your pull request, please fill out this template to the best of your ability.

## Please make sure to complete all of the following steps

1. Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
1. Submit your PR to this repo.
1. ~~[**Submit an accompanying PR Review Request**](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BREP+PR+REVIEW%5D%3A) referencing this PR so the Diego Team knows to review your pull request.~~ 
* ~~**Note: this PR will not be reviewed unless you submit the [PR Review Request](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BREP+PR+REVIEW%5D%3A)**.~~

Not submitting a separate PR Review Request as we already have https://github.com/cloudfoundry/diego-release/issues/662 as a central issue to link PRs to.

***************************

## Please provide the following information:

### What is this change about?

This PR modifies the rep to pass metric tags back to the BBS when calling `StartActualLRP` or `EvacuateRunningActualLRP`.

It introduces a new version of the rep update lrp instance endpoint in order to avoid setting internal routes to nil when different versions of the bbs and rep are present.  @ctlong and @rroberts2222 chatted with @mariash about how to express this in the endpoint path and agreed to express it as a prefix to the URL rather than for example the BBS approach of a revision suffix.

### What problem it is trying to solve?

Ensuring that metric tags are converged when the initial attempt to update the lrp fails.

### What is the impact if the change is not made?

Metric tags may not be applied.

### How should this change be described in diego-release release notes?

It shouldn't be described individually, only as part of the larger change.

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/issues/662
https://github.com/cloudfoundry/bbs/pull/56
https://github.com/cloudfoundry/route-emitter/pull/19

### Tag your pair, your PM, and/or team!

@rroberts2222 @ctlong @Benjamintf1

Thank you!
