### PR TITLE
Move AfterEach logic out of goroutine

### DIFF
--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -233,15 +233,10 @@ var _ = Describe("The Rep", func() {
 	})
 
 	AfterEach(func() {
-		done := make(chan interface{})
-		go func() {
-			close(flushEvents)
-			runner.KillWithFire()
-			fakeGarden.Close()
-			close(done)
-			ginkgomon.Kill(locketProcess)
-		}()
-		Eventually(done).Should(BeClosed())
+		close(flushEvents)
+		runner.KillWithFire()
+		fakeGarden.Close()
+		ginkgomon.Kill(locketProcess)
 	})
 
 	Context("the rep doesn't start", func() {


### PR DESCRIPTION
Most of the code in there includes calls to Eventually and Wait, so we don't need the goroutine/done channel logic.

The only possible issue is fakeGarden.Close, which includes code that acquires/releases a mutex. If we find that tests are hanging on that line, we'll need to wrap that single line in a goroutine managed by a done channel