### PR TITLE
With distributed tracing

### DIFF
--- a/auctioncellrep/auction_cell_rep.go
+++ b/auctioncellrep/auction_cell_rep.go
@@ -368,7 +368,8 @@ func (a *AuctionCellRep) Perform(logger lager.Logger, work rep.Work) (rep.Work, 
 		return work, nil
 	}
 
-	failedWork.LRPs = append(failedWork.LRPs, a.allocator.BatchLRPAllocationRequest(logger, a.enableContainerProxy, a.proxyMemoryAllocation, lrpRequests)...)
+	unallocatedLRPs := a.allocator.BatchLRPAllocationRequest(logger, a.enableContainerProxy, a.proxyMemoryAllocation, lrpRequests)
+	failedWork.LRPs = append(failedWork.LRPs, unallocatedLRPs...)
 	failedWork.Tasks = a.allocator.BatchTaskAllocationRequest(logger, work.Tasks)
 
 	return failedWork, nil

--- a/generator/internal/evacuation_lrp_processor_test.go
+++ b/generator/internal/evacuation_lrp_processor_test.go
@@ -269,7 +269,7 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 
 				Eventually(logger).Should(Say(
 					fmt.Sprintf(
-						`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d\}\],"instance_address":"%s","preferred_address":"%s"\}`,
+						`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d,"host_tls_proxy_port":0\}\],"instance_address":"%s","preferred_address":"%s"\}`,
 						lrpNetInfo.Address,
 						lrpNetInfo.Ports[0].ContainerPort,
 						lrpNetInfo.Ports[0].HostPort,

--- a/generator/internal/ordinary_lrp_processor_test.go
+++ b/generator/internal/ordinary_lrp_processor_test.go
@@ -231,7 +231,7 @@ var _ = Describe("OrdinaryLRPProcessor", func() {
 
 						Eventually(logger).Should(Say(
 							fmt.Sprintf(
-								`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d\}\],"instance_address":"%s","preferred_address":"%s"\}`,
+								`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d\,"host_tls_proxy_port":0}\],"instance_address":"%s","preferred_address":"%s"\}`,
 								expectedNetInfo.Address,
 								expectedNetInfo.Ports[0].ContainerPort,
 								expectedNetInfo.Ports[0].HostPort,

--- a/handlers/cancel_task_handler.go
+++ b/handlers/cancel_task_handler.go
@@ -31,7 +31,7 @@ func (h *cancelTaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, lo
 	}()
 
 	taskGuid := r.FormValue(":task_guid")
-	logger = logger.Session("cancel-task", lager.Data{"instance-guid": taskGuid})
+	logger = logger.Session("cancel-task", lager.Data{"instance-guid": taskGuid}).WithTraceInfo(r)
 
 	w.WriteHeader(http.StatusAccepted)
 

--- a/handlers/container_metrics_handler.go
+++ b/handlers/container_metrics_handler.go
@@ -32,7 +32,7 @@ func (h *containerMetrics) ServeHTTP(w http.ResponseWriter, r *http.Request, log
 	startMetrics(h.metrics, requestType)
 	defer stopMetrics(h.metrics, requestType, start, &deferErr)
 
-	logger = logger.Session("container-metrics-handler")
+	logger = logger.Session("container-metrics-handler").WithTraceInfo(r)
 
 	var metricsCollector *rep.ContainerMetricsCollection
 

--- a/handlers/evacuation_handler.go
+++ b/handlers/evacuation_handler.go
@@ -24,15 +24,11 @@ func newEvacuationHandler(evacuatable evacuation_context.Evacuatable, requestMet
 }
 
 func (h *evacuationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, logger lager.Logger) {
-	var deferErr error
-	//TODO: Come back to this
-	logger = logger.Session("handling-evacuation")
 	h.evacuatable.Evacuate()
 
-	var jsonBytes []byte
-	jsonBytes, deferErr = json.Marshal(map[string]string{"ping_path": "/ping"})
-	if deferErr != nil {
-		logger.Error("failed-to-marshal-response-payload", deferErr)
+	jsonBytes, err := json.Marshal(map[string]string{"ping_path": "/ping"})
+	if err != nil {
+		//THIS SHOULD NEVER HAPPEN
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/handlers/evacuation_handler.go
+++ b/handlers/evacuation_handler.go
@@ -25,8 +25,8 @@ func newEvacuationHandler(evacuatable evacuation_context.Evacuatable, requestMet
 
 func (h *evacuationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, logger lager.Logger) {
 	var deferErr error
+	//TODO: Come back to this
 	logger = logger.Session("handling-evacuation")
-
 	h.evacuatable.Evacuate()
 
 	var jsonBytes []byte

--- a/handlers/perform_handler.go
+++ b/handlers/perform_handler.go
@@ -28,7 +28,7 @@ func (h *perform) ServeHTTP(w http.ResponseWriter, r *http.Request, logger lager
 	startMetrics(h.metrics, requestType)
 	defer stopMetrics(h.metrics, requestType, start, &deferErr)
 
-	logger = logger.Session("auction-perform-work")
+	logger = logger.Session("auction-perform-work").WithTraceInfo(r)
 	var work rep.Work
 	deferErr = json.NewDecoder(r.Body).Decode(&work)
 	if deferErr != nil {

--- a/handlers/reset_handler.go
+++ b/handlers/reset_handler.go
@@ -26,7 +26,7 @@ func (h *reset) ServeHTTP(w http.ResponseWriter, r *http.Request, logger lager.L
 	startMetrics(h.metrics, requestType)
 	defer stopMetrics(h.metrics, requestType, start, &deferErr)
 
-	logger = logger.Session("sim-reset")
+	logger = logger.Session("sim-reset").WithTraceInfo(r)
 
 	deferErr = h.rep.Reset()
 	if deferErr != nil {

--- a/handlers/state_handler.go
+++ b/handlers/state_handler.go
@@ -28,7 +28,7 @@ func (h *state) ServeHTTP(w http.ResponseWriter, r *http.Request, logger lager.L
 	startMetrics(h.metrics, requestType)
 	defer stopMetrics(h.metrics, requestType, start, &deferErr)
 
-	logger = logger.Session("auction-fetch-state")
+	logger = logger.Session("auction-fetch-state").WithTraceInfo(r)
 
 	var state rep.CellState
 	var healthy bool

--- a/handlers/stop_lrp_handler.go
+++ b/handlers/stop_lrp_handler.go
@@ -39,7 +39,7 @@ func (h *StopLRPInstanceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	logger = logger.Session("handling-stop-lrp-instance", lager.Data{
 		"process-guid":  processGuid,
 		"instance-guid": instanceGuid,
-	})
+	}).WithTraceInfo(r)
 
 	if processGuid == "" {
 		deferErr = errors.New("process_guid missing from request")

--- a/handlers/update_lrp_handler.go
+++ b/handlers/update_lrp_handler.go
@@ -40,7 +40,7 @@ func (h *UpdateLRPInstanceHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	logger = logger.Session("handling-update-lrp-instance", lager.Data{
 		"process-guid":  processGuid,
 		"instance-guid": instanceGuid,
-	})
+	}).WithTraceInfo(r)
 
 	if processGuid == "" {
 		deferErr = errors.New("process_guid missing from request")


### PR DESCRIPTION

### What is this change about?

Update Rep logging calls to use new `WithTraceInfo()` method, which appends an `trace-id` based on the `VCAP_REQUEST_ID`. This will allow users to trace a request from Gorouter through Diego components. See https://github.com/cloudfoundry/lager/commit/1e35ce1b4e07747ee2f0fa29052ef0f8c56ed3bd

### What problem it is trying to solve?

Allows operators to troubleshoot a workflow through multiple components of CF.


### How should this change be described in diego-release release notes?

Add zipkin trace-id to Diego (using lager `WithTraceInfo()` method).
