### PR TITLE
enhance test to expect new network traffic usage fields

### DIFF
--- a/handlers/container_metrics_handler_test.go
+++ b/handlers/container_metrics_handler_test.go
@@ -58,6 +58,8 @@ var _ = Describe("ContainerMetrics", func() {
 		Expect(body).To(ContainSubstring(`disk_quota_bytes`))
 		Expect(body).To(ContainSubstring(`memory_usage_bytes`))
 		Expect(body).To(ContainSubstring(`memory_quota_bytes`))
+		Expect(body).To(ContainSubstring(`rx_bytes`))
+		Expect(body).To(ContainSubstring(`tx_bytes`))
 		Expect(body).To(ContainSubstring(`task_guid`))
 		Expect(body).To(ContainSubstring(`metric_guid`))
 		Expect(body).To(ContainSubstring(`cpu_usage_fraction`))
@@ -65,6 +67,8 @@ var _ = Describe("ContainerMetrics", func() {
 		Expect(body).To(ContainSubstring(`disk_quota_bytes`))
 		Expect(body).To(ContainSubstring(`memory_usage_bytes`))
 		Expect(body).To(ContainSubstring(`memory_quota_bytes`))
+		Expect(body).To(ContainSubstring(`rx_bytes`))
+		Expect(body).To(ContainSubstring(`tx_bytes`))
 	})
 
 	It("it returns whatever the container_metrics call returns", func() {


### PR DESCRIPTION
### What is this change about?
Expect new cache fields which has been introduced with https://github.com/cloudfoundry/executor/pull/83/files#diff-ce7c6acd1213d11c38682fac36c436010409569ee2001df1a5f78fce95c57770R10-R11.

### What problem it is trying to solve?
Stakeholders can't observe the network traffic usage for a particular app. 

### What is the impact if the change is not made?
`cf tail -c metrics <app-guid> -f`  will not show `rx_bytes` and `tx_bytes`.

### How should this change be described in diego-release release notes?
Container network traffic is now being sent to the logging stack.

### Please provide any contextual information.
* https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1683732484532129
* https://github.com/cloudfoundry/cf-networking-release/issues/64

### Tag your pair, your PM, and/or team!
* https://github.com/JVecsei1

### Dependencies 
must be merged first: 
* https://github.com/cloudfoundry/diego-logging-client/pull/82
* https://github.com/cloudfoundry/executor/pull/83