### PR TITLE
Fix incorrectly written log line test

### DIFF
--- a/generator/internal/evacuation_lrp_processor_test.go
+++ b/generator/internal/evacuation_lrp_processor_test.go
@@ -284,7 +284,7 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 
 				Eventually(logger).Should(Say(
 					fmt.Sprintf(
-						`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d\}\],"instance_address":"%s","preferred_address":"%s"\}`,
+						`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d,"container_tls_proxy_port":0,"host_tls_proxy_port":0\}\],"instance_address":"%s","preferred_address":"%s"\}`,
 						lrpNetInfo.Address,
 						lrpNetInfo.Ports[0].ContainerPort,
 						lrpNetInfo.Ports[0].HostPort,

--- a/generator/internal/ordinary_lrp_processor_test.go
+++ b/generator/internal/ordinary_lrp_processor_test.go
@@ -240,7 +240,7 @@ var _ = Describe("OrdinaryLRPProcessor", func() {
 
 						Eventually(logger).Should(Say(
 							fmt.Sprintf(
-								`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d\}\],"instance_address":"%s","preferred_address":"%s"\}`,
+								`"net_info":\{"address":"%s","ports":\[\{"container_port":%d,"host_port":%d,"container_tls_proxy_port":0,"host_tls_proxy_port":0\}\],"instance_address":"%s","preferred_address":"%s"\}`,
 								expectedNetInfo.Address,
 								expectedNetInfo.Ports[0].ContainerPort,
 								expectedNetInfo.Ports[0].HostPort,


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

> _Address incorrectly written test within rep's generator/internal lrp process evacuation tests._

### What is the impact if the change is not made?

> _Tests will not pass._