### PR TITLE
set generateLogMetrics on AllocationRequests

### DIFF
--- a/auctioncellrep/batch_container_allocator.go
+++ b/auctioncellrep/batch_container_allocator.go
@@ -84,7 +84,7 @@ func (ca containerAllocator) BatchLRPAllocationRequest(logger lager.Logger, trac
 		containerGuid := rep.LRPContainerGuid(lrp.ProcessGuid, instanceGuid)
 
 		lrpGuidMap[containerGuid] = lrp
-		requests = append(requests, executor.NewAllocationRequest(containerGuid, &resource, buildLRPTags(lrp, instanceGuid)))
+		requests = append(requests, executor.NewAllocationRequest(containerGuid, &resource, true, buildLRPTags(lrp, instanceGuid)))
 	}
 
 	if len(unallocatedLRPs) > 0 {
@@ -126,7 +126,7 @@ func (ca containerAllocator) BatchTaskAllocationRequest(logger lager.Logger, tra
 
 		tags := buildTaskTags(task)
 		resource := executor.NewResource(int(task.MemoryMB), int(task.DiskMB), int(task.MaxPids))
-		requests = append(requests, executor.NewAllocationRequest(task.TaskGuid, &resource, tags))
+		requests = append(requests, executor.NewAllocationRequest(task.TaskGuid, &resource, false, tags))
 	}
 
 	if len(failedTasks) > 0 {

--- a/auctioncellrep/batch_container_allocator_test.go
+++ b/auctioncellrep/batch_container_allocator_test.go
@@ -309,6 +309,7 @@ var _ = Describe("ContainerAllocator", func() {
 				allocationRequest := executor.NewAllocationRequest(
 					task1.TaskGuid,
 					&resource,
+					false,
 					tags,
 				)
 				allocationFailure := executor.NewAllocationFailure(&allocationRequest, commonErr.Error())
@@ -428,6 +429,7 @@ func allocationRequestFromLRP(lrp rep.LRP) executor.AllocationRequest {
 	return executor.NewAllocationRequest(
 		lrp.InstanceGUID,
 		&resource,
+		true,
 		executor.Tags{
 			rep.LifecycleTag:     rep.LRPLifecycle,
 			rep.DomainTag:        lrp.Domain,
@@ -445,6 +447,7 @@ func allocationRequestFromTask(task rep.Task, placementTags, volumeDrivers strin
 	return executor.NewAllocationRequest(
 		task.TaskGuid,
 		&resource,
+		false,
 		executor.Tags{
 			rep.LifecycleTag:     rep.TaskLifecycle,
 			rep.DomainTag:        task.Domain,


### PR DESCRIPTION

## Please provide the following information:

### What is this change about?

- previously we were generate log metrics for tasks, while not generating any other container metrics for tasks.
- change batch_container_allocator to set the new bool to true for LRPs and false for Tasks
- Please note this change depends on the change to the Executor which adds the bool to the AllocationRequest struct.

### What problem it is trying to solve?

log rate metrics being erroneously generated for tasks

### What is the impact if the change is not made?

Task containers will continue to generate log rate metrics (that don't have the correct tags) and no other container metrics

### How should this change be described in diego-release release notes?

Log rate limit metrics are no longer generated for tasks
### Tag your pair, your PM, and/or team!

@rroberts2222 
