### PR TITLE
Send AZ in StartActualLRP/EvacuateRunningActualLRP requests to BBS

### DIFF
--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -148,6 +148,7 @@ func main() {
 
 	opGenerator := generator.New(
 		repConfig.CellID,
+		repConfig.Zone,
 		rootFSMap,
 		repConfig.LayeringMode,
 		bbsClient,

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -29,6 +29,7 @@ type Generator interface {
 
 type generator struct {
 	cellID            string
+	availabilityZone  string
 	bbs               bbs.InternalClient
 	executorClient    executor.Client
 	lrpProcessor      internal.LRPProcessor
@@ -38,6 +39,7 @@ type generator struct {
 
 func New(
 	cellID string,
+	availabilityZone string,
 	stackPathMap rep.StackPathMap,
 	layeringMode string,
 	bbs bbs.InternalClient,
@@ -46,7 +48,7 @@ func New(
 	evacuationReporter evacuation_context.EvacuationReporter,
 ) Generator {
 	containerDelegate := internal.NewContainerDelegate(executorClient)
-	lrpProcessor := internal.NewLRPProcessor(bbs, containerDelegate, metronClient, cellID, stackPathMap, layeringMode, evacuationReporter)
+	lrpProcessor := internal.NewLRPProcessor(bbs, containerDelegate, metronClient, cellID, availabilityZone, stackPathMap, layeringMode, evacuationReporter)
 	taskProcessor := internal.NewTaskProcessor(bbs, containerDelegate, cellID, stackPathMap, layeringMode)
 
 	return &generator{

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -24,6 +24,7 @@ func (BogusEvent) EventType() executor.EventType {
 var _ = Describe("Generator", func() {
 	var (
 		cellID             string
+		availabilityZone   string
 		fakeExecutorClient *efakes.FakeClient
 
 		opGenerator generator.Generator
@@ -31,9 +32,10 @@ var _ = Describe("Generator", func() {
 
 	BeforeEach(func() {
 		cellID = "some-cell-id"
+		availabilityZone = "some-zone"
 		fakeExecutorClient = new(efakes.FakeClient)
 		fakeEvacuationReporter := &fake_evacuation_context.FakeEvacuationReporter{}
-		opGenerator = generator.New(cellID, rep.StackPathMap{}, "", fakeBBS, fakeExecutorClient, nil, fakeEvacuationReporter)
+		opGenerator = generator.New(cellID, availabilityZone, rep.StackPathMap{}, "", fakeBBS, fakeExecutorClient, nil, fakeEvacuationReporter)
 	})
 
 	Describe("BatchOperations", func() {

--- a/generator/internal/evacuation_lrp_processor_test.go
+++ b/generator/internal/evacuation_lrp_processor_test.go
@@ -23,7 +23,8 @@ import (
 var _ = Describe("EvacuationLrpProcessor", func() {
 	Describe("Process", func() {
 		const (
-			localCellID = "cell-α"
+			localCellID           = "cell-α"
+			localAvailabilityZone = "some-zone"
 		)
 
 		var (
@@ -57,7 +58,7 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 
 			fakeMetronClient = new(mfakes.FakeIngressClient)
 
-			lrpProcessor = internal.NewLRPProcessor(fakeBBS, fakeContainerDelegate, fakeMetronClient, localCellID, rep.StackPathMap{}, "", fakeEvacuationReporter)
+			lrpProcessor = internal.NewLRPProcessor(fakeBBS, fakeContainerDelegate, fakeMetronClient, localCellID, localAvailabilityZone, rep.StackPathMap{}, "", fakeEvacuationReporter)
 
 			processGuid = "process-guid"
 			desiredLRP = models.DesiredLRP{
@@ -273,7 +274,7 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 
 			It("evacuates the lrp", func() {
 				Expect(fakeBBS.EvacuateRunningActualLRPCallCount()).To(Equal(1))
-				_, traceID, actualLRPKey, actualLRPContainerKey, actualLRPNetInfo, internalRoutes, metricTags, routable := fakeBBS.EvacuateRunningActualLRPArgsForCall(0)
+				_, traceID, actualLRPKey, actualLRPContainerKey, actualLRPNetInfo, internalRoutes, metricTags, routable, availabilityZone := fakeBBS.EvacuateRunningActualLRPArgsForCall(0)
 				Expect(traceID).To(Equal("some-trace-id"))
 				Expect(*actualLRPKey).To(Equal(lrpKey))
 				Expect(*actualLRPContainerKey).To(Equal(lrpInstanceKey))
@@ -281,6 +282,7 @@ var _ = Describe("EvacuationLrpProcessor", func() {
 				Expect(internalRoutes).To(Equal([]*models.ActualLRPInternalRoute{{Hostname: "some-internal-route.apps.internal"}, {Hostname: "some-other-internal-route"}}))
 				Expect(metricTags).To(Equal(map[string]string{"app_name": "some-application"}))
 				Expect(routable).To(Equal(true))
+				Expect(availabilityZone).To(Equal(localAvailabilityZone))
 
 				Eventually(logger).Should(Say(
 					fmt.Sprintf(

--- a/generator/internal/lrp_processor.go
+++ b/generator/internal/lrp_processor.go
@@ -41,12 +41,13 @@ func NewLRPProcessor(
 	containerDelegate ContainerDelegate,
 	metronClient loggingclient.IngressClient,
 	cellID string,
+	availabilityZone string,
 	stackPathMap rep.StackPathMap,
 	layeringMode string,
 	evacuationReporter evacuation_context.EvacuationReporter,
 ) LRPProcessor {
-	ordinaryProcessor := newOrdinaryLRPProcessor(bbsClient, containerDelegate, cellID, stackPathMap, layeringMode)
-	evacuationProcessor := newEvacuationLRPProcessor(bbsClient, containerDelegate, metronClient, cellID)
+	ordinaryProcessor := newOrdinaryLRPProcessor(bbsClient, containerDelegate, cellID, availabilityZone, stackPathMap, layeringMode)
+	evacuationProcessor := newEvacuationLRPProcessor(bbsClient, containerDelegate, metronClient, cellID, availabilityZone)
 	return &lrpProcessor{
 		evacuationReporter:  evacuationReporter,
 		ordinaryProcessor:   ordinaryProcessor,

--- a/generator/internal/ordinary_lrp_processor.go
+++ b/generator/internal/ordinary_lrp_processor.go
@@ -13,6 +13,7 @@ type ordinaryLRPProcessor struct {
 	bbsClient                  bbs.InternalClient
 	containerDelegate          ContainerDelegate
 	cellID                     string
+	availabilityZone           string
 	stackPathMap               rep.StackPathMap
 	layeringMode               string
 	runRequestConversionHelper rep.RunRequestConversionHelper
@@ -22,6 +23,7 @@ func newOrdinaryLRPProcessor(
 	bbsClient bbs.InternalClient,
 	containerDelegate ContainerDelegate,
 	cellID string,
+	availabilityZone string,
 	stackPathMap rep.StackPathMap,
 	layeringMode string,
 ) LRPProcessor {
@@ -31,6 +33,7 @@ func newOrdinaryLRPProcessor(
 		bbsClient:                  bbsClient,
 		containerDelegate:          containerDelegate,
 		cellID:                     cellID,
+		availabilityZone:           availabilityZone,
 		stackPathMap:               stackPathMap,
 		layeringMode:               layeringMode,
 		runRequestConversionHelper: runRequestConversionHelper,
@@ -127,7 +130,7 @@ func (p *ordinaryLRPProcessor) processRunningContainer(logger lager.Logger, trac
 	for _, internalRoute := range lrpContainer.InternalRoutes {
 		internalRoutes = append(internalRoutes, &models.ActualLRPInternalRoute{Hostname: internalRoute.Hostname})
 	}
-	err = p.bbsClient.StartActualLRP(logger, traceID, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes, lrpContainer.MetricsConfig.Tags, lrpContainer.Routable)
+	err = p.bbsClient.StartActualLRP(logger, traceID, lrpContainer.ActualLRPKey, lrpContainer.ActualLRPInstanceKey, netInfo, internalRoutes, lrpContainer.MetricsConfig.Tags, lrpContainer.Routable, p.availabilityZone)
 	bbsErr := models.ConvertError(err)
 	if bbsErr != nil && bbsErr.Type == models.Error_ActualLRPCannotBeStarted {
 		p.containerDelegate.StopContainer(logger, traceID, lrpContainer.Guid)


### PR DESCRIPTION
### What is this change about?

Rep will pass availability zone it is configured with in BBS calls  `StartActualLRP` and `EvacuateRunningActualLRP`.

### What problem it is trying to solve?

This will allow BBS to store and pass through availability zone to the Route Emitter which will advertise in Registry Message for the Gorouter so that it can make decisions based on balancing algorithm.

### How should this change be described in diego-release release notes?

[Feature] Diego advertises the availability zone of an LRP to enable clever intra-AZ routing

### Please provide any contextual information.

[tracker story](https://www.pivotaltracker.com/story/show/186117279)
[issue](https://github.com/cloudfoundry/routing-release/issues/356)

Thank you!
