### PR TITLE
Adds metric tags to task logs

### DIFF
--- a/conversion_helpers.go
+++ b/conversion_helpers.go
@@ -186,7 +186,7 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromDesiredLRP(
 		return executor.RunRequest{}, err
 	}
 
-	metricTags, err := models.ConvertMetricTags(desiredLRP.MetricTags, map[models.MetricTagValue_DynamicValue]interface{}{
+	metricTags, err := models.ConvertMetricTags(desiredLRP.MetricTags, map[models.MetricTagValue_DynamicValue]any{
 		models.MetricTagDynamicValueIndex:        lrpKey.Index,
 		models.MetricTagDynamicValueInstanceGuid: lrpInstanceKey.InstanceGuid,
 	})
@@ -276,6 +276,11 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromTask(task *models.Task, 
 		return executor.RunRequest{}, err
 	}
 
+	metricTags, err := models.ConvertMetricTags(task.MetricTags, map[models.MetricTagValue_DynamicValue]any{})
+	if err != nil {
+		return executor.RunRequest{}, err
+	}
+
 	username, password, err := rrch.convertCredentials(rootFSPath, task.ImageUsername, task.ImagePassword)
 	if err != nil {
 		return executor.RunRequest{}, err
@@ -291,9 +296,11 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromTask(task *models.Task, 
 		LogConfig: executor.LogConfig{
 			Guid:       task.LogGuid,
 			SourceName: task.LogSource,
+			Tags:       metricTags,
 		},
 		MetricsConfig: executor.MetricsConfig{
 			Guid: task.MetricsGuid,
+			Tags: metricTags,
 		},
 		CachedDependencies:            ConvertCachedDependencies(cachedDependencies),
 		Action:                        task.Action,

--- a/conversion_helpers_test.go
+++ b/conversion_helpers_test.go
@@ -627,7 +627,7 @@ var _ = Describe("Resources", func() {
 					Expect(runReq.RunInfo.LogConfig.Tags).To(HaveKeyWithValue("tag1", "foo"))
 				})
 
-				It("populates tags with dynamic values according its enum value ", func() {
+				It("populates tags with dynamic values according to its enum value", func() {
 					runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(runReq.RunInfo.MetricsConfig.Tags).To(HaveKeyWithValue("index", "9"))
@@ -696,9 +696,15 @@ var _ = Describe("Resources", func() {
 					LogConfig: executor.LogConfig{
 						Guid:       task.LogGuid,
 						SourceName: task.LogSource,
+						Tags: map[string]string{
+							"source_id": "some-metrics-guid",
+						},
 					},
 					MetricsConfig: executor.MetricsConfig{
 						Guid: task.MetricsGuid,
+						Tags: map[string]string{
+							"source_id": "some-metrics-guid",
+						},
 					},
 					Action:                        task.Action,
 					Env:                           executor.EnvironmentVariablesFromModel(task.EnvironmentVariables),
@@ -725,6 +731,16 @@ var _ = Describe("Resources", func() {
 					EnableContainerProxy:       false,
 					LogRateLimitBytesPerSecond: -1,
 				}))
+			})
+
+			Context("when the task tags contain dynamic fields not applicable to tasks", func() {
+				BeforeEach(func() {
+					task.MetricTags["index"] = &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex}
+				})
+				It("errors", func() {
+					_, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).To(HaveOccurred())
+				})
 			})
 
 			Context("when the network is nil", func() {


### PR DESCRIPTION
### What is this change about?

Adds metric tags to tasks. Merge [this PR](https://github.com/cloudfoundry/bbs/pull/77) first.

### What problem it is trying to solve?

Operator wants to see app/space/org names in task logs.

### What is the impact if the change is not made?

No consistency between LRP and task logs in regards to tags.

### How should this change be described in diego-release release notes?

Task logs include tags.

### Please provide any contextual information.

https://github.com/cloudfoundry/bbs/pull/77

### Tag your pair, your PM, and/or team!

@acrmp 

Thank you!

