### PR TITLE
Do not remove evacuating actual LRP during cleanup

### DIFF
--- a/evacuation/cleanup.go
+++ b/evacuation/cleanup.go
@@ -78,10 +78,6 @@ func (e *EvacuationCleanup) Run(signals <-chan os.Signal, ready chan<- struct{})
 		}
 
 		strandedEvacuationCount++
-		err = e.bbsClient.RemoveEvacuatingActualLRP(logger, traceID, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey)
-		if err != nil {
-			logger.Error("failed-removing-evacuating-actual-lrp", err, lager.Data{"lrp-key": actualLRP.ActualLRPKey})
-		}
 	}
 
 	err = e.metronClient.SendMetric(strandedEvacuatingActualLRPsMetric, strandedEvacuationCount)

--- a/evacuation/cleanup_test.go
+++ b/evacuation/cleanup_test.go
@@ -134,26 +134,6 @@ var _ = Describe("EvacuationCleanup", func() {
 			cleanupProcess.Signal(os.Kill)
 		})
 
-		It("removes all evacuating actual lrps associated with the cell", func() {
-			Eventually(errCh).Should(Receive(nil))
-			Expect(fakeBBSClient.ActualLRPsCallCount()).To(Equal(1))
-			_, traceID, filter := fakeBBSClient.ActualLRPsArgsForCall(0)
-			Expect(traceID).To(BeEmpty())
-			Expect(filter).To(Equal(models.ActualLRPFilter{CellID: cellID}))
-
-			Expect(fakeBBSClient.RemoveEvacuatingActualLRPCallCount()).To(Equal(2))
-
-			_, traceID, lrpKey, lrpInstanceKey := fakeBBSClient.RemoveEvacuatingActualLRPArgsForCall(0)
-			Expect(traceID).To(BeEmpty())
-			Expect(*lrpKey).To(Equal(evacuatingActualLRP.ActualLRPKey))
-			Expect(*lrpInstanceKey).To(Equal(evacuatingActualLRP.ActualLRPInstanceKey))
-
-			_, traceID, lrpKey, lrpInstanceKey = fakeBBSClient.RemoveEvacuatingActualLRPArgsForCall(1)
-			Expect(traceID).To(BeEmpty())
-			Expect(*lrpKey).To(Equal(evacuatingActualLRPWithReplacement.ActualLRPKey))
-			Expect(*lrpInstanceKey).To(Equal(evacuatingActualLRPWithReplacement.ActualLRPInstanceKey))
-		})
-
 		It("logs the number of stranded evacuating actual lrps", func() {
 			Eventually(logger).Should(gbytes.Say("finished-evacuating.*\"stranded-evacuating-actual-lrps\":2"))
 		})
@@ -316,17 +296,6 @@ var _ = Describe("EvacuationCleanup", func() {
 				var err error
 				Eventually(errCh).Should(Receive(&err))
 				Expect(err).To(Equal(errors.New("failed")))
-			})
-		})
-
-		Describe("when removing the evacuating actual lrp fails", func() {
-			BeforeEach(func() {
-				fakeBBSClient.RemoveEvacuatingActualLRPReturns(errors.New("failed"))
-			})
-
-			It("continues removing evacuating actual lrps", func() {
-				Eventually(errCh).Should(Receive(nil))
-				Expect(fakeBBSClient.RemoveEvacuatingActualLRPCallCount()).To(Equal(2))
 			})
 		})
 	})


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Evacuating actual LRP will be removed by BBS convergence or after the replacement LRP is started. No need to bombard BBS during cell updates. This will minimize the drain time and it will actually stay close to the configured drain timeout. Cleanup is happening after the timeout is reached and BBS requests can overload BBS and cause it to timeout each request (10s) by default.

Backward Compatibility
---------------
Breaking Change? **No**
