### PR TITLE
Remove cfhttp v1 call, dockerdriver removed it

### DIFF
--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -16,7 +16,6 @@ import (
 
 	"code.cloudfoundry.org/bbs"
 	"code.cloudfoundry.org/bbs/models"
-	"code.cloudfoundry.org/cfhttp"
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/debugserver"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
@@ -70,9 +69,6 @@ func main() {
 	if *zoneOverride != "" {
 		repConfig.Zone = *zoneOverride
 	}
-
-	// We need to keep this here since dockerdriver still uses cfhttp v1
-	cfhttp.Initialize(time.Duration(repConfig.CommunicationTimeout))
 
 	clock := clock.NewClock()
 	logger, reconfigurableSink := lagerflags.NewFromConfig(repConfig.SessionName, repConfig.LagerConfig)


### PR DESCRIPTION


- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Merge in this PR once the PR to remove cfhttp v1 from dockerdriver is merged in:
- https://github.com/cloudfoundry/dockerdriver/pull/61

[#187603786](https://www.pivotaltracker.com/story/show/187603786)

Backward Compatibility
---------------
Breaking Change? Nope
