### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -306,7 +306,10 @@ func startTLSServer(addr string, handler http.Handler, tlsConfig *tls.Config) if
 		}
 		listener = tls.NewListener(listener, tlsConfig)
 		close(ready)
-		go http.Serve(listener, handler)
+		server := &http.Server{
+			Handler: handler,
+		}
+		go server.Serve(listener)
 		<-signals
 		return listener.Close()
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Use `Server` struct, which allows specifying a timeout, to address gosec G114

Backward Compatibility
---------------
Breaking Change? **No**
