### PR TITLE
Add read header timeout to address G112

### DIFF
--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -307,7 +307,8 @@ func startTLSServer(addr string, handler http.Handler, tlsConfig *tls.Config) if
 		listener = tls.NewListener(listener, tlsConfig)
 		close(ready)
 		server := &http.Server{
-			Handler: handler,
+			Handler:           handler,
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 		go server.Serve(listener)
 		<-signals


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds a ReadHeaderTimeout for http.Servers


Backward Compatibility
---------------
Breaking Change? no