### PR TITLE
Update the rootFSes to be an array instead of a map

### DIFF
--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -58,6 +58,14 @@ func (rootFSes RootFSes) Names() []string {
 	return names
 }
 
+func (rootFSes RootFSes) Paths() []string {
+	paths := make([]string, len(rootFSes))
+	for i, rootFS := range rootFSes {
+		paths[i] = rootFS.Path
+	}
+	return paths
+}
+
 func (rootFSes RootFSes) StackPathMap() rep.StackPathMap {
 	m := make(rep.StackPathMap)
 	for _, rootFS := range rootFSes {

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -89,8 +89,9 @@ func main() {
 	}
 
 	rootFSMap := repConfig.PreloadedRootFS.StackPathMap()
+	rootFSes := repConfig.PreloadedRootFS.Paths()
 
-	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, metronClient, clock)
+	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSes, metronClient, clock)
 	if err != nil {
 		logger.Error("failed-to-initialize-executor", err)
 		os.Exit(1)
@@ -135,7 +136,7 @@ func main() {
 	)
 
 	requestTypes := []string{
-		"State", "ContainerMetrics", "Perform", "Reset", "UpdateLRPInstance", "StopLRPInstance", "CancelTask", //over https only
+		"State", "ContainerMetrics", "Perform", "Reset", "UpdateLRPInstance", "StopLRPInstance", "CancelTask", // over https only
 	}
 	requestMetrics := helpers.NewRequestMetricsNotifier(logger, clock, metronClient, time.Duration(repConfig.ReportInterval), requestTypes)
 	httpServer := initializeServer(auctionCellRep, executorClient, evacuatable, requestMetrics, logger, repConfig, false)
@@ -271,7 +272,6 @@ func initializeServer(
 	handlers := handlers.New(auctionCellRep, auctionCellRep, executorClient, evacuatable, requestMetrics, logger, networkAccessible)
 	routes := rep.NewRoutes(networkAccessible)
 	router, err := rata.NewRouter(routes, handlers)
-
 	if err != nil {
 		logger.Fatal("failed-to-construct-router", err)
 	}

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -459,7 +459,6 @@ var _ = Describe("The Rep", func() {
 
 			It("uses the last rootfs", func() {
         Expect(repConfig.PreloadedRootFS).To(HaveLen(2))
-        fmt.Println(createRequestReceived)
 				Eventually(createRequestReceived).Should(Receive(And(
 					ContainSubstring(`check-`),
           ContainSubstring(`"rootfs":"/path/to/another/rootfs"`),

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -458,9 +458,11 @@ var _ = Describe("The Rep", func() {
 			})
 
 			It("uses the last rootfs", func() {
+        Expect(repConfig.PreloadedRootFS).To(HaveLen(2))
+        fmt.Println(createRequestReceived)
 				Eventually(createRequestReceived).Should(Receive(And(
 					ContainSubstring(`check-`),
-					ContainSubstring(`/rootfs`),
+          ContainSubstring(`"rootfs":"/path/to/another/rootfs"`),
 				)))
 			})
 		})

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -64,7 +64,7 @@ var _ = Describe("The Rep", func() {
 		flushEvents chan struct{}
 	)
 
-	var getActualLRPs = func(logger lager.Logger) func() []*models.ActualLRP {
+	getActualLRPs := func(logger lager.Logger) func() []*models.ActualLRP {
 		return func() []*models.ActualLRP {
 			actualLRPs, err := bbsClient.ActualLRPs(logger, requestIdHeader, models.ActualLRPFilter{})
 			Expect(err).NotTo(HaveOccurred())
@@ -451,13 +451,13 @@ var _ = Describe("The Rep", func() {
 
 		Context("when there are multiple rootfses", func() {
 			BeforeEach(func() {
-				repConfig.PreloadedRootFS = append([]config.RootFS{{
+				repConfig.PreloadedRootFS = append(repConfig.PreloadedRootFS, config.RootFS{
 					Name: "another",
 					Path: "/path/to/another/rootfs",
-				}}, repConfig.PreloadedRootFS...)
+				})
 			})
 
-			It("uses the first rootfs", func() {
+			It("uses the last rootfs", func() {
 				Eventually(createRequestReceived).Should(Receive(And(
 					ContainSubstring(`check-`),
 					ContainSubstring(`/rootfs`),
@@ -570,7 +570,6 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 		})
 
 		Describe("maintaining presence", func() {
-
 			var response *locketmodels.FetchResponse
 
 			It("should maintain presence", func() {
@@ -748,9 +747,7 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 				})
 
 				Context("when an lrp is requested", func() {
-					var (
-						placementTags, volumeDrivers []string
-					)
+					var placementTags, volumeDrivers []string
 
 					BeforeEach(func() {
 						placementTags = []string{"pg-1"}
@@ -1056,9 +1053,7 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 			})
 
 			Context("while the healthcheck container is being created", func() {
-				var (
-					blockCh chan struct{}
-				)
+				var blockCh chan struct{}
 
 				BeforeEach(func() {
 					blockCh = make(chan struct{})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are always used in a consistent way. The map was removed in favour of an array. The FSes should be stored in ascending order, ie. [ cflinuxfs3, cflinuxfs4 ]

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just making sure the fses are used in a consistent way
