### PR TITLE
Add the SidecarFS functionality

### DIFF
--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -66,13 +66,6 @@ func (rootFSes RootFSes) StackPathMap() rep.StackPathMap {
 	return m
 }
 
-func SidecarRootFSPath(sidecarFS string, rootFSes RootFSes) string {
-	if sidecarFS == "" {
-		return rootFSes[0].Path
-	}
-	return sidecarFS
-}
-
 func (m RootFSes) MarshalJSON() (b []byte, err error) {
 	arr := make([]string, len(m))
 	for i, rootFS := range m {

--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -97,7 +97,7 @@ type RepConfig struct {
 	PlacementTags             []string              `json:"placement_tags"`
 	PollingInterval           durationjson.Duration `json:"polling_interval,omitempty"`
 	PreloadedRootFS           RootFSes              `json:"preloaded_root_fs"`
-	SidecarRootFSPath         string                `json:"sidecar_root_fs"`
+	SidecarRootFSPath         string                `json:"sidecar_root_fs_path"`
 	ServerCertFile            string                `json:"server_cert_file"` // DEPRECATED. Kept around for dusts compatability
 	ServerKeyFile             string                `json:"server_key_file"`  // DEPRECATED. Kept around for dusts compatability
 	CertFile                  string                `json:"cert_file"`

--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -66,11 +66,11 @@ func (rootFSes RootFSes) StackPathMap() rep.StackPathMap {
 	return m
 }
 
-func SidecarRootFSPath(sidecarFS RootFS, rootFSes RootFSes) string {
-	if sidecarFS == (RootFS{}) || sidecarFS.Path == "" {
+func SidecarRootFSPath(sidecarFS string, rootFSes RootFSes) string {
+	if sidecarFS == "" {
 		return rootFSes[0].Path
 	}
-	return sidecarFS.Path
+	return sidecarFS
 }
 
 func (m RootFSes) MarshalJSON() (b []byte, err error) {
@@ -104,7 +104,7 @@ type RepConfig struct {
 	PlacementTags             []string              `json:"placement_tags"`
 	PollingInterval           durationjson.Duration `json:"polling_interval,omitempty"`
 	PreloadedRootFS           RootFSes              `json:"preloaded_root_fs"`
-	SidecarRootFS             RootFS                `json:"sidecar_root_fs"`
+	SidecarRootFSPath         string                `json:"sidecar_root_fs"`
 	ServerCertFile            string                `json:"server_cert_file"` // DEPRECATED. Kept around for dusts compatability
 	ServerKeyFile             string                `json:"server_key_file"`  // DEPRECATED. Kept around for dusts compatability
 	CertFile                  string                `json:"cert_file"`

--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -97,6 +97,7 @@ type RepConfig struct {
 	PlacementTags             []string              `json:"placement_tags"`
 	PollingInterval           durationjson.Duration `json:"polling_interval,omitempty"`
 	PreloadedRootFS           RootFSes              `json:"preloaded_root_fs"`
+	SidecarRootFS             RootFS                `json:"sidecar_root_fs"`
 	ServerCertFile            string                `json:"server_cert_file"` // DEPRECATED. Kept around for dusts compatability
 	ServerKeyFile             string                `json:"server_key_file"`  // DEPRECATED. Kept around for dusts compatability
 	CertFile                  string                `json:"cert_file"`

--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -66,6 +66,13 @@ func (rootFSes RootFSes) StackPathMap() rep.StackPathMap {
 	return m
 }
 
+func SidecarRootFSPath(sidecarFS RootFS, rootFSes RootFSes) string {
+	if sidecarFS == (RootFS{}) || sidecarFS.Path == "" {
+		return rootFSes[0].Path
+	}
+	return sidecarFS.Path
+}
+
 func (m RootFSes) MarshalJSON() (b []byte, err error) {
 	arr := make([]string, len(m))
 	for i, rootFS := range m {

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -90,7 +90,9 @@ func main() {
 
 	rootFSMap := repConfig.PreloadedRootFS.StackPathMap()
 
-	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, metronClient, clock)
+	sidecarFSPath := repConfig.SidecarRootFS.Path
+
+	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarFSPath, metronClient, clock)
 	if err != nil {
 		logger.Error("failed-to-initialize-executor", err)
 		os.Exit(1)
@@ -135,7 +137,7 @@ func main() {
 	)
 
 	requestTypes := []string{
-		"State", "ContainerMetrics", "Perform", "Reset", "UpdateLRPInstance", "StopLRPInstance", "CancelTask", //over https only
+		"State", "ContainerMetrics", "Perform", "Reset", "UpdateLRPInstance", "StopLRPInstance", "CancelTask", // over https only
 	}
 	requestMetrics := helpers.NewRequestMetricsNotifier(logger, clock, metronClient, time.Duration(repConfig.ReportInterval), requestTypes)
 	httpServer := initializeServer(auctionCellRep, executorClient, evacuatable, requestMetrics, logger, repConfig, false)
@@ -271,7 +273,6 @@ func initializeServer(
 	handlers := handlers.New(auctionCellRep, auctionCellRep, executorClient, evacuatable, requestMetrics, logger, networkAccessible)
 	routes := rep.NewRoutes(networkAccessible)
 	router, err := rata.NewRouter(routes, handlers)
-
 	if err != nil {
 		logger.Fatal("failed-to-construct-router", err)
 	}

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -89,10 +89,9 @@ func main() {
 	}
 
 	rootFSMap := repConfig.PreloadedRootFS.StackPathMap()
+	sidecarRootFSPath := repConfig.SidecarRootFSPath
 
-	sidecarFSPath := config.SidecarRootFSPath(repConfig.SidecarRootFSPath, repConfig.PreloadedRootFS)
-
-	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarFSPath, metronClient, clock)
+	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarRootFSPath, metronClient, clock)
 	if err != nil {
 		logger.Error("failed-to-initialize-executor", err)
 		os.Exit(1)

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	rootFSMap := repConfig.PreloadedRootFS.StackPathMap()
 
-	sidecarFSPath := config.SidecarRootFSPath(repConfig.SidecarRootFS, repConfig.PreloadedRootFS)
+	sidecarFSPath := config.SidecarRootFSPath(repConfig.SidecarRootFSPath, repConfig.PreloadedRootFS)
 
 	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarFSPath, metronClient, clock)
 	if err != nil {

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	rootFSMap := repConfig.PreloadedRootFS.StackPathMap()
 
-	sidecarFSPath := repConfig.SidecarRootFS.Path
+	sidecarFSPath := config.SidecarRootFSPath(repConfig.SidecarRootFS, repConfig.PreloadedRootFS)
 
 	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarFSPath, metronClient, clock)
 	if err != nil {

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -468,10 +468,10 @@ var _ = Describe("The Rep", func() {
 		Context("when there is an explixitly specified rootfs path", func() {
 			BeforeEach(func() {
 				repConfig.PreloadedRootFS = append(repConfig.PreloadedRootFS, config.RootFS{
-        	Name: "another",
-	        Path: "/path/to/another/rootfs",
-        })
-        repConfig.SidecarRootFSPath = "/path/to/another/rootfs"
+					Name: "another",
+					Path: "/path/to/another/rootfs",
+				})
+				repConfig.SidecarRootFSPath = "/path/to/another/rootfs"
 			})
 
 			It("uses the specified rootfs path", func() {

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -452,16 +452,32 @@ var _ = Describe("The Rep", func() {
 		Context("when there are multiple rootfses", func() {
 			BeforeEach(func() {
 				repConfig.PreloadedRootFS = append([]config.RootFS{{
-					Name: "sidecar",
-					Path: "/path/to/sidecar/rootfs",
+					Name: "another",
+					Path: "/path/to/another/rootfs",
 				}}, repConfig.PreloadedRootFS...)
-        repConfig.SidecarRootFSPath = "/path/to/sidecar/rootfs"
 			})
 
-			It("uses the specified rootfs", func() {
+			It("uses the first rootfs", func() {
 				Eventually(createRequestReceived).Should(Receive(And(
 					ContainSubstring(`check-`),
-					ContainSubstring(`/path/to/sidecar/rootfs`),
+					ContainSubstring(`/rootfs`),
+				)))
+			})
+		})
+
+		Context("when there is an explixitly specified rootfs path", func() {
+			BeforeEach(func() {
+				repConfig.PreloadedRootFS = append(repConfig.PreloadedRootFS, config.RootFS{
+        	Name: "another",
+	        Path: "/path/to/another/rootfs",
+        })
+        repConfig.SidecarRootFSPath = "/path/to/another/rootfs"
+			})
+
+			It("uses the specified rootfs path", func() {
+				Eventually(createRequestReceived).Should(Receive(And(
+					ContainSubstring(`check-`),
+					ContainSubstring(`/path/to/another/rootfs`),
 				)))
 			})
 		})

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -452,15 +452,16 @@ var _ = Describe("The Rep", func() {
 		Context("when there are multiple rootfses", func() {
 			BeforeEach(func() {
 				repConfig.PreloadedRootFS = append([]config.RootFS{{
-					Name: "another",
-					Path: "/path/to/another/rootfs",
+					Name: "sidecar",
+					Path: "/path/to/sidecar/rootfs",
 				}}, repConfig.PreloadedRootFS...)
+        repConfig.SidecarRootFS = config.RootFS{Name: "sidecar", Path: "/path/to/sidecar/rootfs"}
 			})
 
-			It("uses the first rootfs", func() {
+			It("uses the specified rootfs", func() {
 				Eventually(createRequestReceived).Should(Receive(And(
 					ContainSubstring(`check-`),
-					ContainSubstring(`/rootfs`),
+					ContainSubstring(`/path/to/sidecar/rootfs`),
 				)))
 			})
 		})

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -455,7 +455,7 @@ var _ = Describe("The Rep", func() {
 					Name: "sidecar",
 					Path: "/path/to/sidecar/rootfs",
 				}}, repConfig.PreloadedRootFS...)
-        repConfig.SidecarRootFS = config.RootFS{Name: "sidecar", Path: "/path/to/sidecar/rootfs"}
+        repConfig.SidecarRootFSPath = "/path/to/sidecar/rootfs"
 			})
 
 			It("uses the specified rootfs", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are used in a consistent way. We have added a SidecarRootFS that will store the FS to be used for the envoy & healthchecks.

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just making sure the fses are used in a consistent way
<!---