### PR TITLE
RFC-0030: Add support for file-based service bindings

### DIFF
--- a/conversion_helpers.go
+++ b/conversion_helpers.go
@@ -250,6 +250,7 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromDesiredLRP(
 		EnableContainerProxy:          true,
 		Sidecars:                      convertSidecars(desiredLRP.Sidecars),
 		LogRateLimitBytesPerSecond:    convertLogRateLimit(desiredLRP.LogRateLimit),
+		VolumeMountedFiles:            executor.VolumeMountedFilesFromModel(desiredLRP.VolumeMountedFiles),
 	}
 
 	// No need for the envoy proxy if there are no ports.  This flag controls the
@@ -321,6 +322,7 @@ func (rrch RunRequestConversionHelper) NewRunRequestFromTask(task *models.Task, 
 		ImagePassword:                 password,
 		EnableContainerProxy:          false,
 		LogRateLimitBytesPerSecond:    convertLogRateLimit(task.LogRateLimit),
+		VolumeMountedFiles:            executor.VolumeMountedFilesFromModel(task.VolumeMountedFiles),
 	}
 	return executor.NewRunRequest(task.TaskGuid, &runInfo, tags), nil
 }

--- a/conversion_helpers_test.go
+++ b/conversion_helpers_test.go
@@ -283,15 +283,18 @@ var _ = Describe("Resources", func() {
 
 		Describe("NewRunRequestFromDesiredLRP", func() {
 			var (
-				containerGuid string
-				desiredLRP    *models.DesiredLRP
-				actualLRP     *models.ActualLRP
-				stackPathMap  rep.StackPathMap
+				containerGuid      string
+				desiredLRP         *models.DesiredLRP
+				desiredLRPNoVolume *models.DesiredLRP
+				actualLRP          *models.ActualLRP
+				stackPathMap       rep.StackPathMap
+				runInfo            executor.RunInfo
 			)
 
 			BeforeEach(func() {
 				containerGuid = "the-container-guid"
 				desiredLRP = model_helpers.NewValidDesiredLRP("the-process-guid")
+				desiredLRPNoVolume = model_helpers.NewValidDesiredLRPWithNoVolumeMountedFiles("the-process-guid")
 				desiredLRP.Ports = []uint32{8080}
 				// This is a lazy way to prevent old tests from failing.  The tests
 				// happily ignored ImageLayer that used to be returned from
@@ -318,13 +321,13 @@ var _ = Describe("Resources", func() {
 						DiskMb:   6,
 					},
 				}
-			})
 
-			It("returns a valid run request", func() {
-				runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(runReq.Tags).To(Equal(executor.Tags{}))
-				Expect(runReq.RunInfo).To(test_helpers.DeepEqual(executor.RunInfo{
+				desiredLRPNoVolume.Ports = desiredLRP.Ports
+				desiredLRPNoVolume.ImageLayers = nil
+				desiredLRPNoVolume.RootFs = desiredLRP.RootFs
+				desiredLRPNoVolume.Sidecars = desiredLRP.Sidecars
+
+				runInfo = executor.RunInfo{
 					RootFSPath: stackPathMap["cflinuxfs3"],
 					CPUWeight:  uint(desiredLRP.CpuWeight),
 					Ports:      rep.ConvertPortMappings(desiredLRP.Ports),
@@ -395,7 +398,28 @@ var _ = Describe("Resources", func() {
 						},
 					},
 					LogRateLimitBytesPerSecond: -1,
-				}))
+					VolumeMountedFiles:         []executor.VolumeMountedFiles{{Path: "/redis/username", Content: "redis_user"}},
+				}
+			})
+
+			It("returns a valid run request", func() {
+				runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(runReq.Tags).To(Equal(executor.Tags{}))
+
+				Expect(runReq.RunInfo).To(test_helpers.DeepEqual(runInfo))
+
+			})
+
+			It("return a valid run request with no volume mounted files", func() {
+				runReqNoVolume, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRPNoVolume, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(runReqNoVolume.Tags).To(Equal(executor.Tags{}))
+
+				runInfo.VolumeMountedFiles = []executor.VolumeMountedFiles{}
+				Expect(runReqNoVolume.RunInfo).To(test_helpers.DeepEqual(runInfo))
+
 			})
 
 			Context("when the network is nil", func() {
@@ -680,6 +704,7 @@ var _ = Describe("Resources", func() {
 			var (
 				task         *models.Task
 				stackPathMap rep.StackPathMap
+				runInfo      executor.RunInfo
 			)
 
 			BeforeEach(func() {
@@ -691,22 +716,17 @@ var _ = Describe("Resources", func() {
 				// explicitly for V2 conversion in a context below
 				task.ImageLayers = nil
 				task.RootFs = "preloaded:cflinuxfs3"
+				task.VolumeMountedFiles = []*models.File{
+					{Path: "/redis/username", Content: "username"},
+				}
 
 				stackPathMap = rep.StackPathMap{
 					"cflinuxfs3": "cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar",
 				}
 
 				task.LogRateLimit = &models.LogRateLimit{BytesPerSecond: -1}
-			})
 
-			It("returns a valid run request", func() {
-				runReq, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(runReq.Tags).To(Equal(executor.Tags{
-					rep.ResultFileTag: task.ResultFile,
-				}))
-
-				Expect(runReq.RunInfo).To(Equal(executor.RunInfo{
+				runInfo = executor.RunInfo{
 					RootFSPath: stackPathMap["cflinuxfs3"],
 					CPUWeight:  uint(task.CpuWeight),
 					Privileged: task.Privileged,
@@ -751,7 +771,32 @@ var _ = Describe("Resources", func() {
 					ImagePassword:              "image-password",
 					EnableContainerProxy:       false,
 					LogRateLimitBytesPerSecond: -1,
+					VolumeMountedFiles:         []executor.VolumeMountedFiles{{Path: "/redis/username", Content: "username"}},
+				}
+			})
+
+			It("returns a valid run request", func() {
+				runReq, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(runReq.Tags).To(Equal(executor.Tags{
+					rep.ResultFileTag: task.ResultFile,
 				}))
+
+				Expect(runReq.RunInfo).To(Equal(runInfo))
+			})
+
+			It("returns a valid run request with no volume mounted files", func() {
+				task.VolumeMountedFiles = []*models.File{}
+				runReq, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(runReq.Tags).To(Equal(executor.Tags{
+					rep.ResultFileTag: task.ResultFile,
+				}))
+
+				runInfo.VolumeMountedFiles = []executor.VolumeMountedFiles{}
+
+				Expect(runReq.RunInfo).To(Equal(runInfo))
 			})
 
 			Context("when the task tags contain dynamic fields not applicable to tasks", func() {


### PR DESCRIPTION
Co-authored-by:

[Dimitar Dimitrov] <dimitar.dimitrov13@sap.com>
[Plamen Doychev] <plamen.doychev@sap.com>


Summary
---------------
Related to https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0030-add-support-for-file-based-service-binding.md


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
