### PR TITLE
Add support for extra-rootfs-dir

### DIFF
--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -88,6 +88,7 @@ type RepConfig struct {
 	CommunicationTimeout      durationjson.Duration `json:"communication_timeout,omitempty"`
 	EvacuationPollingInterval durationjson.Duration `json:"evacuation_polling_interval,omitempty"`
 	EvacuationTimeout         durationjson.Duration `json:"evacuation_timeout,omitempty"`
+	ExtraRootfsDir            string                `json:"extra_root_fs_dir"`
 	LayeringMode              string                `json:"layering_mode,omitempty"`
 	ListenAddr                string                `json:"listen_addr,omitempty"`
 	ListenAddrSecurable       string                `json:"listen_addr_securable,omitempty"`


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This will help inject/load a rootfs from filesystem outside of rep.json configuration


Backward Compatibility
---------------
Breaking Change? **No**
