### PR TITLE
Skip preloaded fs tests on Windows

### DIFF
--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -377,10 +377,13 @@ var _ = Describe("The Rep", func() {
 		})
 	})
 
-	Describe("creates containers to retrieve the sizes of the configured preloaded rootfses", func() {
+	Describe("creates containers to retrieve the sizes of the configured preloaded rootfses on linux", func() {
 		var createRequestReceived chan string
 
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("Skipping preloaded fs on windows")
+			}
 			fakeGarden.Start()
 			respondWithSuccessToCreateContainer = false
 			createRequestReceived = make(chan string)


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Preloaded fs tests break the pipelines


Backward Compatibility
---------------
Breaking Change? No