### PR TITLE
Parse dedicated volume mount for executor

### DIFF
--- a/conversion_helpers_test.go
+++ b/conversion_helpers_test.go
@@ -497,6 +497,28 @@ var _ = Describe("Resources", func() {
 						Mode: executor.BindMountModeRO,
 					}))
 				})
+
+				Context("when MountConfig is invalid JSON", func() {
+					BeforeEach(func() {
+						desiredLRP.VolumeMounts[0].Dedicated.MountConfig = "{{"
+					})
+
+					It("returns an error", func() {
+						_, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+						Expect(err).To(HaveOccurred())
+					})
+				})
+
+				Context("when DeviceConfig is invalid JSON", func() {
+					BeforeEach(func() {
+						desiredLRP.VolumeMounts[0].Dedicated.DeviceConfig = "{{"
+					})
+
+					It("returns an error", func() {
+						_, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+						Expect(err).To(HaveOccurred())
+					})
+				})
 			})
 
 			It("enables the envoy proxy", func() {

--- a/conversion_helpers_test.go
+++ b/conversion_helpers_test.go
@@ -468,6 +468,37 @@ var _ = Describe("Resources", func() {
 				})
 			})
 
+			Context("when a volumeMount is dedicated", func() {
+				BeforeEach(func() {
+					desiredLRP.VolumeMounts[0] = &models.VolumeMount{
+						Dedicated: &models.DedicatedDevice{
+							MounterId:    "my-mounter-id",
+							MountConfig:  `{"foo":"bar"}`,
+							DeviceConfig: `{"baz":"qux"}`,
+						},
+						Driver:       "my-driver",
+						ContainerDir: "/mnt/mypath",
+						Mode:         "r",
+					}
+				})
+
+				It("returns a dedicated volume mount", func() {
+					runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(runReq.VolumeMounts).To(ConsistOf(executor.VolumeMount{
+						Driver:        "my-driver",
+						VolumeId:      "my-mounter-id-9",
+						ContainerPath: "/mnt/mypath",
+						Config: map[string]interface{}{
+							"mount_config":  map[string]interface{}{"foo": "bar"},
+							"device_config": map[string]interface{}{"baz": "qux"},
+							"source":        "my-mounter-id-9",
+						},
+						Mode: executor.BindMountModeRO,
+					}))
+				})
+			})
+
 			It("enables the envoy proxy", func() {
 				runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Parse Dedicated volume mount from LRP and pass it to volman. If volume mount contains Dedicated device then it should be parsed too.

Related BBS change:
https://github.com/cloudfoundry/bbs/pull/142


Backward Compatibility
---------------
Breaking Change? **No**
