### PR TITLE
gcrhelper: add automatic GCR/Artifact Registry auth on GCE

### DIFF
--- a/conversion_helpers.go
+++ b/conversion_helpers.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/ecrhelper"
 	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/gcrhelper"
 	"code.cloudfoundry.org/routing-info/internalroutes"
 )
 
@@ -167,6 +168,7 @@ func ConvertPreloadedRootFS(rootFS string, imageLayers []*models.ImageLayer, lay
 
 type RunRequestConversionHelper struct {
 	ECRHelper ecrhelper.ECRHelper
+	GCRHelper gcrhelper.GCRHelper
 }
 
 func (rrch RunRequestConversionHelper) NewRunRequestFromDesiredLRP(
@@ -357,6 +359,17 @@ func convertImageLayers(t *models.TaskDefinition) ([]*models.CachedDependency, *
 }
 
 func (rrch RunRequestConversionHelper) convertCredentials(rootFS string, username string, password string) (string, string, error) {
+	if username == "" && password == "" {
+		isGCRRepo, err := rrch.GCRHelper.IsGCRRepo(rootFS)
+		if err != nil {
+			return "", "", err
+		}
+
+		if isGCRRepo {
+			return rrch.GCRHelper.GetGCRCredentials()
+		}
+	}
+
 	isECRRepo, err := rrch.ECRHelper.IsECRRepo(rootFS)
 	if err != nil {
 		return "", "", err

--- a/conversion_helpers_test.go
+++ b/conversion_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/test_helpers"
 	fakeecrhelper "code.cloudfoundry.org/ecrhelper/fakes"
 	"code.cloudfoundry.org/executor"
+	fakegcrhelper "code.cloudfoundry.org/gcrhelper/fakes"
 	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/routing-info/internalroutes"
 	. "github.com/onsi/ginkgo/v2"
@@ -283,12 +284,15 @@ var _ = Describe("Resources", func() {
 		var (
 			runRequestConversionHelper rep.RunRequestConversionHelper
 			fakeECRHelper              *fakeecrhelper.FakeECRHelper
+			fakeGCRHelper              *fakegcrhelper.FakeGCRHelper
 		)
 
 		BeforeEach(func() {
 			fakeECRHelper = &fakeecrhelper.FakeECRHelper{}
+			fakeGCRHelper = &fakegcrhelper.FakeGCRHelper{}
 			runRequestConversionHelper = rep.RunRequestConversionHelper{
 				ECRHelper: fakeECRHelper,
+				GCRHelper: fakeGCRHelper,
 			}
 		})
 
@@ -570,6 +574,50 @@ var _ = Describe("Resources", func() {
 				It("uses TotalDiskLimit as the disk scope", func() {
 					_, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
 					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("when the rootfs is a GCR/Artifact Registry repo URL and no credentials are stored", func() {
+				BeforeEach(func() {
+					desiredLRP.ImageUsername = ""
+					desiredLRP.ImagePassword = ""
+					fakeGCRHelper.IsGCRRepoReturns(true, nil)
+					fakeGCRHelper.GetGCRCredentialsReturns("oauth2accesstoken", "some-fresh-token", nil)
+				})
+
+				It("uses the metadata-server token", func() {
+					runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(runReq.ImageUsername).To(Equal("oauth2accesstoken"))
+					Expect(runReq.ImagePassword).To(Equal("some-fresh-token"))
+				})
+
+				Context("when checking for GCR repo fails", func() {
+					BeforeEach(func() {
+						fakeGCRHelper.IsGCRRepoReturns(false, errors.New("disaster"))
+					})
+
+					It("returns an error", func() {
+						_, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+						Expect(err).To(HaveOccurred())
+					})
+				})
+
+			})
+
+			Context("when the rootfs is a GCR/Artifact Registry repo URL but credentials are stored", func() {
+				BeforeEach(func() {
+					desiredLRP.ImageUsername = "_json_key"
+					desiredLRP.ImagePassword = `{"type":"service_account"}`
+				})
+
+				It("passes through the stored credentials without checking GCR", func() {
+					runReq, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(containerGuid, desiredLRP, &actualLRP.ActualLRPKey, &actualLRP.ActualLRPInstanceKey, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(runReq.ImageUsername).To(Equal("_json_key"))
+					Expect(runReq.ImagePassword).To(Equal(`{"type":"service_account"}`))
+					Expect(fakeGCRHelper.IsGCRRepoCallCount()).To(Equal(0))
+					Expect(fakeGCRHelper.GetGCRCredentialsCallCount()).To(Equal(0))
 				})
 			})
 
@@ -917,6 +965,52 @@ var _ = Describe("Resources", func() {
 				It("uses TotalDiskLimit as the disk scope", func() {
 					_, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
 					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("when the rootfs is a GCR/Artifact Registry repo URL and no credentials are stored", func() {
+				BeforeEach(func() {
+					task.RootFs = "docker://europe-west3-docker.pkg.dev/my-project/my-repo/my-image:latest"
+					task.ImageUsername = ""
+					task.ImagePassword = ""
+					fakeGCRHelper.IsGCRRepoReturns(true, nil)
+					fakeGCRHelper.GetGCRCredentialsReturns("oauth2accesstoken", "some-fresh-token", nil)
+				})
+
+				It("uses the metadata-server token", func() {
+					runReq, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(runReq.ImageUsername).To(Equal("oauth2accesstoken"))
+					Expect(runReq.ImagePassword).To(Equal("some-fresh-token"))
+				})
+
+				Context("when checking for GCR repo fails", func() {
+					BeforeEach(func() {
+						fakeGCRHelper.IsGCRRepoReturns(false, errors.New("disaster"))
+					})
+
+					It("returns an error", func() {
+						_, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+						Expect(err).To(HaveOccurred())
+					})
+				})
+
+			})
+
+			Context("when the rootfs is a GCR/Artifact Registry repo URL but credentials are stored", func() {
+				BeforeEach(func() {
+					task.RootFs = "docker://europe-west3-docker.pkg.dev/my-project/my-repo/my-image:latest"
+					task.ImageUsername = "_json_key"
+					task.ImagePassword = `{"type":"service_account"}`
+				})
+
+				It("passes through the stored credentials without checking GCR", func() {
+					runReq, err := runRequestConversionHelper.NewRunRequestFromTask(task, stackPathMap, rep.LayeringModeSingleLayer)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(runReq.ImageUsername).To(Equal("_json_key"))
+					Expect(runReq.ImagePassword).To(Equal(`{"type":"service_account"}`))
+					Expect(fakeGCRHelper.IsGCRRepoCallCount()).To(Equal(0))
+					Expect(fakeGCRHelper.GetGCRCredentialsCallCount()).To(Equal(0))
 				})
 			})
 

--- a/generator/internal/ordinary_lrp_processor.go
+++ b/generator/internal/ordinary_lrp_processor.go
@@ -5,6 +5,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/ecrhelper"
 	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/gcrhelper"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/rep"
 )
@@ -27,7 +28,10 @@ func newOrdinaryLRPProcessor(
 	stackPathMap rep.StackPathMap,
 	layeringMode string,
 ) LRPProcessor {
-	runRequestConversionHelper := rep.RunRequestConversionHelper{ECRHelper: ecrhelper.NewECRHelper()}
+	runRequestConversionHelper := rep.RunRequestConversionHelper{
+		ECRHelper: ecrhelper.NewECRHelper(),
+		GCRHelper: gcrhelper.NewGCRHelper(),
+	}
 
 	return &ordinaryLRPProcessor{
 		bbsClient:                  bbsClient,

--- a/generator/internal/ordinary_lrp_processor_test.go
+++ b/generator/internal/ordinary_lrp_processor_test.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/bbs/models/test/model_helpers"
 	fakeecrhelper "code.cloudfoundry.org/ecrhelper/fakes"
 	"code.cloudfoundry.org/executor"
+	fakegcrhelper "code.cloudfoundry.org/gcrhelper/fakes"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/rep/evacuation/evacuation_context/fake_evacuation_context"
@@ -139,7 +140,10 @@ var _ = Describe("OrdinaryLRPProcessor", func() {
 					It("runs the container", func() {
 						Expect(containerDelegate.RunContainerCallCount()).To(Equal(1))
 
-						runRequestConversionHelper := rep.RunRequestConversionHelper{ECRHelper: &fakeecrhelper.FakeECRHelper{}}
+						runRequestConversionHelper := rep.RunRequestConversionHelper{
+							ECRHelper: &fakeecrhelper.FakeECRHelper{},
+							GCRHelper: &fakegcrhelper.FakeGCRHelper{},
+						}
 						expectedRunRequest, err := runRequestConversionHelper.NewRunRequestFromDesiredLRP(container.Guid, desiredLRP, &expectedLrpKey, &expectedInstanceKey, rep.StackPathMap{}, "")
 						Expect(err).NotTo(HaveOccurred())
 

--- a/generator/internal/task_processor.go
+++ b/generator/internal/task_processor.go
@@ -5,6 +5,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/ecrhelper"
 	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/gcrhelper"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/rep"
 )
@@ -30,7 +31,10 @@ type taskProcessor struct {
 }
 
 func NewTaskProcessor(bbs bbs.InternalClient, containerDelegate ContainerDelegate, cellID string, stackPathMap rep.StackPathMap, layeringMode string) TaskProcessor {
-	runRequestConversionHelper := rep.RunRequestConversionHelper{ECRHelper: ecrhelper.NewECRHelper()}
+	runRequestConversionHelper := rep.RunRequestConversionHelper{
+		ECRHelper: ecrhelper.NewECRHelper(),
+		GCRHelper: gcrhelper.NewGCRHelper(),
+	}
 
 	return &taskProcessor{
 		bbsClient:                  bbs,

--- a/generator/internal/task_processor_test.go
+++ b/generator/internal/task_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/bbs/models/test/model_helpers"
 	fakeecrhelper "code.cloudfoundry.org/ecrhelper/fakes"
 	"code.cloudfoundry.org/executor"
+	fakegcrhelper "code.cloudfoundry.org/gcrhelper/fakes"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/rep"
 	"code.cloudfoundry.org/rep/generator/internal"
@@ -42,7 +43,10 @@ var _ = Describe("TaskProcessor", func() {
 		processor = internal.NewTaskProcessor(bbsClient, containerDelegate, expectedCellID, rep.StackPathMap{}, "")
 
 		task = model_helpers.NewValidTask(taskGuid)
-		runRequestConversionHelper := rep.RunRequestConversionHelper{ECRHelper: &fakeecrhelper.FakeECRHelper{}}
+		runRequestConversionHelper := rep.RunRequestConversionHelper{
+			ECRHelper: &fakeecrhelper.FakeECRHelper{},
+			GCRHelper: &fakegcrhelper.FakeGCRHelper{},
+		}
 		expectedRunRequest, err = runRequestConversionHelper.NewRunRequestFromTask(task, rep.StackPathMap{}, "")
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

## Summary

Part of cloudfoundry/diego-release#1124. See that PR for full details.

Adds GCR credential lookup to `convertCredentials()` in `conversion_helpers.go`: if no credentials are stored for a docker image and the URL matches a GCR/Artifact Registry host, the GCE instance metadata server is queried for an OAuth2 token. Falls back silently on non-GCE environments.

## Backward Compatibility

Breaking Change? **No**

The new code only runs when no credentials are stored for the image. All existing behaviour is preserved.