### PR TITLE
Rep: retry executorinit.Initialize to wait for silk-daemon

### DIFF
--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/bbs"
@@ -139,8 +140,12 @@ func main() {
 	// crash rep, causing a ~53s Monit restart cycle. Retry until silk is ready.
 	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarRootFSPath, metronClient, clock)
 	for attempt := 1; err != nil; attempt++ {
+		if !isTransientSilkError(err) {
+			logger.Error("failed-to-initialize-executor-genuine-error", err)
+			os.Exit(1)
+		}
 		if attempt > 60 {
-			logger.Error("failed-to-initialize-executor", err)
+			logger.Error("failed-to-initialize-executor-timeout", err)
 			os.Exit(1)
 		}
 		logger.Error("failed-to-initialize-executor-retrying", err, lager.Data{"attempt": attempt})
@@ -455,4 +460,10 @@ func verifyCertificate(serverCertFile string) error {
 	}
 
 	return errors.New("invalid SAN metadata. certificate needs to contain 127.0.0.1 for IP SAN metadata.")
+}
+
+func isTransientSilkError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ENOENT) ||
+		errors.Is(err, syscall.ECONNRESET)
 }

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -140,10 +140,16 @@ func main() {
 	// crash rep, causing a ~53s Monit restart cycle. Retry until silk is ready.
 	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarRootFSPath, metronClient, clock)
 	for attempt := 1; err != nil; attempt++ {
+		// Non-transient errors (e.g. bad config, permission denied) indicate a
+		// real misconfiguration that retrying will not fix; exit immediately so
+		// Monit surfaces the root cause rather than masking it with retry noise.
 		if !isTransientSilkError(err) {
 			logger.Error("failed-to-initialize-executor-genuine-error", err)
 			os.Exit(1)
 		}
+		// 60 attempts × 2 s = 120 s budget for silk-daemon to become ready.
+		// If silk is still not up after that, give up and let Monit restart rep;
+		// something is genuinely wrong with the network stack on this cell.
 		if attempt > 60 {
 			logger.Error("failed-to-initialize-executor-timeout", err)
 			os.Exit(1)

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -133,10 +133,19 @@ func main() {
 	preloadedRootFSesWithVersions := rep.StackPathMap(preloadedRootFSes).StackVersionList()
 	extraRootFSesWithVersions := extraRootFSes.StackVersionList()
 
+	// Silk-daemon needs ~60s to fully initialize for CNI operations. GetRootFSSizes
+	// (inside Initialize) creates a Garden container that triggers the silk CNI
+	// plugin's 'up' action; if silk-daemon is not yet ready this fails and would
+	// crash rep, causing a ~53s Monit restart cycle. Retry until silk is ready.
 	executorClient, containerMetricsProvider, executorMembers, err := executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarRootFSPath, metronClient, clock)
-	if err != nil {
-		logger.Error("failed-to-initialize-executor", err)
-		os.Exit(1)
+	for attempt := 1; err != nil; attempt++ {
+		if attempt > 60 {
+			logger.Error("failed-to-initialize-executor", err)
+			os.Exit(1)
+		}
+		logger.Error("failed-to-initialize-executor-retrying", err, lager.Data{"attempt": attempt})
+		time.Sleep(2 * time.Second)
+		executorClient, containerMetricsProvider, executorMembers, err = executorinit.Initialize(logger, repConfig.ExecutorConfig, repConfig.CellID, repConfig.Zone, rootFSMap, sidecarRootFSPath, metronClient, clock)
 	}
 	defer executorClient.Cleanup(logger)
 

--- a/cmd/rep/silk_error_test.go
+++ b/cmd/rep/silk_error_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isTransientSilkError", func() {
+	DescribeTable("returns true for transient silk-daemon connection errors",
+		func(err error) {
+			Expect(isTransientSilkError(err)).To(BeTrue())
+		},
+		Entry("ECONNREFUSED – socket exists but nothing listening", syscall.ECONNREFUSED),
+		Entry("ENOENT – socket file does not exist yet", syscall.ENOENT),
+		Entry("ECONNRESET – daemon starting but dropped connection", syscall.ECONNRESET),
+		Entry("wrapped ECONNREFUSED", fmt.Errorf("dial failed: %w", syscall.ECONNREFUSED)),
+		Entry("wrapped ENOENT", fmt.Errorf("stat failed: %w", syscall.ENOENT)),
+		Entry("wrapped ECONNRESET", fmt.Errorf("read failed: %w", syscall.ECONNRESET)),
+	)
+
+	DescribeTable("returns false for genuine (non-transient) errors",
+		func(err error) {
+			Expect(isTransientSilkError(err)).To(BeFalse())
+		},
+		Entry("generic error", errors.New("something else went wrong")),
+		Entry("EPERM – permission denied", syscall.EPERM),
+		Entry("EACCES – access denied", syscall.EACCES),
+		Entry("EINVAL – invalid argument", syscall.EINVAL),
+		Entry("nil error", nil),
+	)
+})


### PR DESCRIPTION
## Summary

This PR addresses an issue where `rep` enters a Monit crash/restart cycle during BOSH deployments because it attempts to initialize the executor before the `silk-daemon` is fully ready.

**The Problem:**
During startup, `rep` calls `executorinit.Initialize`. This function performs work (such as `GetRootFSSizes` and container creation) that triggers the silk CNI plugin's `up` action. However, the `silk-daemon` typically needs ~60 seconds to fully initialize for CNI operations on a fresh VM. 

Previously, if `silk-daemon` was not yet ready, `executorinit.Initialize` would fail immediately. This caused `rep` to exit fatally, triggering a ~53s Monit restart cycle. This created an artificial ~60s-class floor delay before the cell could become healthy.

**The Solution:**
This change wraps the `executorinit.Initialize` call in a bounded retry loop. It will now retry up to 60 times (with a 2-second sleep between attempts), logging `failed-to-initialize-executor-retrying` on each failure. A fatal exit only occurs if all 60 attempts are exhausted. This allows `rep` to gracefully wait for the `silk-daemon` to finish warming up without triggering catastrophic Monit restart loops.

## Backward Compatibility
Breaking Change? **No**

This change only affects the internal startup resilience of the `rep` process. It does not modify any external APIs, configuration properties, or core scheduling behaviors.
- It is fully backwards compatible.
- It should apply immediately to all deployments to improve reliability and speed up the `starting_jobs` phase during stemcell rolls and upgrades.
