### PR TITLE
go fmt fix

### DIFF
--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -787,7 +787,7 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 					value := &models.CellPresence{}
 					err = json.Unmarshal([]byte(response.Resource.Value), value)
 					Expect(err).NotTo(HaveOccurred())
-					
+
 					Expect(value.RepUrl).To(Equal("https://custom-override.example.com:9876"))
 					Expect(value.CellId).To(Equal(repConfig.CellID))
 					Expect(value.Zone).To(Equal(repConfig.Zone))
@@ -808,14 +808,14 @@ dYbCU/DMZjsv+Pt9flhj7ELLo+WKHyI767hJSq9A7IT3GzFt8iGiEAt1qj2yS0DX
 					value := &models.CellPresence{}
 					err = json.Unmarshal([]byte(response.Resource.Value), value)
 					Expect(err).NotTo(HaveOccurred())
-					
+
 					// Expected format: https://{repHost(CellID)}.{AdvertiseDomain}:{port}
 					// repHost converts underscores to hyphens
-					expectedURL := fmt.Sprintf("https://%s.%s:%d", 
+					expectedURL := fmt.Sprintf("https://%s.%s:%d",
 						strings.Replace(repConfig.CellID, "_", "-", -1),
-						repConfig.AdvertiseDomain, 
+						repConfig.AdvertiseDomain,
 						serverPortSecurable)
-					
+
 					Expect(value.RepUrl).To(Equal(expectedURL))
 					Expect(value.CellId).To(Equal(repConfig.CellID))
 					Expect(value.Zone).To(Equal(repConfig.Zone))


### PR DESCRIPTION
ai-assisted=no
TNZ-1234

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
go fmt fix


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
