### PR TITLE
rep: update metron-down test for non-blocking loggregator dial (tnz-96145)

### DIFF
--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -249,9 +249,11 @@ var _ = Describe("The Rep", func() {
 				testIngressServer.Stop()
 			})
 
-			It("logs an error and exit with non-zero status code", func() {
-				Eventually(runner.Session).Should(Exit(1))
-				Expect(runner.Session).To(gbytes.Say("failed-to-initialize-metron-client"))
+			// diego-logging-client now dials loggregator non-blocking (lazy). rep
+			// starts successfully and retries the connection in the background, so
+			// it must NOT exit when metron is temporarily unavailable.
+			It("starts successfully and does not exit", func() {
+				Consistently(runner.Session).ShouldNot(Exit())
 			})
 		})
 


### PR DESCRIPTION
## Summary
diego-logging-client [tnz-96145](https://github.com/cloudfoundry/diego-logging-client/pull/XXX) removed grpc.WithBlock() and grpc.WithTimeout(1s) from NewIngressClient, making the Loggregator v2 gRPC connection non-blocking. Instead of failing at startup if the loggregator agent is unavailable, rep now establishes the connection lazily in the background and retries automatically.

Prior to this change, rep would log "failed-to-initialize-metron-client" and exit with status 1 within ~1 second of startup if metron_agent was not yet listening. During BOSH rolling upgrades, this caused rep to enter a ~53s Monit restart cycle even when the underlying Diego cell was otherwise healthy.

After this change, rep starts successfully regardless of metron availability and connects in the background. This is consistent with the treatment of other transient startup dependencies addressed in this upgrade resilience work.

The test "when the metron agent isn't up → logs an error and exit with non-zero status code" was asserting the old blocking-dial behaviour. This PR updates it to assert the new correct behaviour: rep starts and keeps running when metron is temporarily unavailable.

## What changed
cmd/rep/main_test.go — replaced Eventually(runner.Session).Should(Exit(1)) with Consistently(runner.Session).ShouldNot(Exit()) and updated the description accordingly.

## Backward Compatibility
Breaking Change? No

This is a test-only change. No production behaviour is modified. The test now correctly reflects the actual behaviour of rep after the diego-logging-client non-blocking dial change.