### PR TITLE
Add optional cell annotations field to CellPresence

### DIFF
--- a/cmd/rep/config/config.go
+++ b/cmd/rep/config/config.go
@@ -83,6 +83,7 @@ type RepConfig struct {
 	BBSClientCertFile               string                `json:"bbs_client_cert_file"` // DEPRECATED. Kept around for dusts compatability
 	BBSClientKeyFile                string                `json:"bbs_client_key_file"`  // DEPRECATED. Kept around for dusts compatability
 	CaCertFile                      string                `json:"ca_cert_file"`
+	CellAnnotations                 map[string]string     `json:"cell_annotations,omitempty"`
 	CellID                          string                `json:"cell_id"`
 	CellIndex                       int                   `json:"cell_index"`
 	CommunicationTimeout            durationjson.Duration `json:"communication_timeout,omitempty"`

--- a/cmd/rep/main.go
+++ b/cmd/rep/main.go
@@ -321,7 +321,8 @@ func initializeCellPresence(
 	cellCapacity := models.NewCellCapacity(int32(resources.MemoryMB), int32(resources.DiskMB), int32(resources.Containers))
 	cellPresence := models.NewCellPresence(repConfig.CellID, address, repUrl,
 		repConfig.Zone, cellCapacity, repConfig.SupportedProviders,
-		preloadedRootFSesWithVersions, extraRootFSesWithVersions, repConfig.PlacementTags, repConfig.OptionalPlacementTags)
+		preloadedRootFSesWithVersions, extraRootFSesWithVersions, repConfig.PlacementTags, repConfig.OptionalPlacementTags,
+		repConfig.CellAnnotations)
 
 	payload, err := json.Marshal(cellPresence)
 	if err != nil {


### PR DESCRIPTION
- Adds properties for a Diego cell rep to be able to provide arbitrary metadata about the cell