### PR TITLE
Fix BBS binding to port on Windows

### DIFF
--- a/cmd/rep/main_suite_test.go
+++ b/cmd/rep/main_suite_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -230,6 +231,15 @@ var _ = AfterEach(func() {
 
 	ginkgomon.Kill(bbsProcess)
 	Eventually(bbsProcess.Wait()).Should(Receive())
+
+	Eventually(func() error {
+		l, err := net.Listen("tcp", bbsConfig.HealthAddress)
+		if err != nil {
+			return err
+		}
+		return l.Close()
+	}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+
 	testIngressServer.Stop()
 	close(signalMetricsChan)
 	sqlRunner.Reset()

--- a/cmd/rep/main_test.go
+++ b/cmd/rep/main_test.go
@@ -95,8 +95,8 @@ var _ = Describe("The Rep", func() {
 		bbsClient, err = bbs.NewClient(bbsURL.String(), caFile, clientCertFile, clientKeyFile, 0, 0)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(getActualLRPs(logger)).Should(BeEmpty())
 		flushEvents = make(chan struct{})
+		Eventually(getActualLRPs(logger)).Should(BeEmpty())
 		fakeGarden = ghttp.NewUnstartedServer()
 		// these tests only look for the start of a sequence of requests
 		fakeGarden.AllowUnhandledRequests = false


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
On Windows the TCP/IP stack may not release ports synchronously with process exit. Poll until the BBS health-check port is actually free so the next BeforeEach can bind it without a WSAEADDRINUSE error.

Backward Compatibility
---------------
Breaking Change? **No**